### PR TITLE
docs(KL-15): add git commit template

### DIFF
--- a/.gitmessage.txt
+++ b/.gitmessage.txt
@@ -1,0 +1,64 @@
+# 커밋 메시지 템플릿
+# - 형식: <jira issue key>/<type>: <short summary>
+# ▼ <header> 작성
+
+# ▼ <빈 줄>
+
+# ▼ <body> 작성
+
+# ▼ <빈 줄>
+
+# ▼ <footer> 작성
+
+# 작성 형식 설명
+#   - 일반 커밋
+#     <header>
+#		 <jira issue key>
+#           - jira issue key 알아서 넣으세용
+#        <type>
+#		    - feat: 새로운 기능 추가
+#           - fix: 버그 수정
+#           - docs: 문서 수정
+#           - style: 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
+#           - design: 사용자 UI 변경 (CSS 변경 등)
+#	        - refactor: 코드 리팩토링
+#           - test: 테스트 코드, 리팩토링 테스트 코드 추가
+#           - chore:	빌드 업무 수정, 패키지 매니저 수정, production code와 무관한 부분들 (.gitignore, build.gradle 같은)
+#           - comment:	주석 추가 및 변경
+#           - rename: 파일, 폴더명 수정
+#           - remove: 파일, 폴더 삭제
+#       <short summary>
+#           - 필수 입력
+#           - 변경 사항을 간결하게 설명
+#           - 첫글자 소문자, 현재 시제, 명령문으로 마지막에 .(마침표) 없이 작성
+#
+#     <body>
+#       - 최소 20자 필수 입력(<type>docs 제외)
+#       - 현재 시제, 명령문으로 작성
+#       - 변경 사항의 동기(왜)를 설명
+#       - 변경 효과를 설명하기 위해 이전 동작과 현재 동작의 비교를 포함할 수 있음
+#
+#     <footer>
+#       - Breaking Changes, deprecations 또는 이 커밋이 close하거나 연관된 깃헙 이슈, 지라 티켓, 풀리퀘스트 포함
+#       - 예시
+#         - 1. Breaking Changes
+#           BREAKING CHANGE: <breaking change 요약>
+#           <빈 줄>
+#           <breaking change 설명 + migration 지시>
+#           <빈 줄>
+#           <빈 줄>
+#           Fixes #<issue number>
+#         - 2. deprecations
+#           DEPRECATED: <deprecated 된 것>
+#           <빈 줄>
+#           <deprecation 설명 + 추천 update 경로>
+#           <빈 줄>
+#           <빈 줄>
+#           Closes #<pr 번호>
+#
+#   - Revert 커밋
+#     <header>
+#       revert: <revert 대상 커밋의 헤더>
+#     <body>
+#       - This reverts commit <revert 대상 커밋의 SHA>
+#       - revert 이유에 대한 명확한 설명


### PR DESCRIPTION
## 📌 연관된 이슈
- **[KL-15/[BE] git 커밋 템플릿 적용](https://ohhamma.atlassian.net/browse/KL-15)**

## 📝 작업 내용
- `.gitmessage.txt` 커밋 메시지 템플릿을 추가했습니다.
- `git config --local commit.template .gitmessage.txt` 명령어로 적용가능합니다.
- `git commit` 명령어 실행시 템플릿이 열립니다.
- 커밋 메시지 작성 후 `:wq` 로 저장시 커밋이 완료됩니다.


## 🌳 작업 브랜치명
- `KL-15/be-git-커밋-템플릿-적용`

## 📸 스크린샷 (선택)

## 💬 리뷰 요구사항 (선택)