### PR TITLE
chore(KL-100): set up sql initialization

### DIFF
--- a/src/main/java/taco/klkl/domain/user/controller/UserController.java
+++ b/src/main/java/taco/klkl/domain/user/controller/UserController.java
@@ -6,13 +6,16 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
 import taco.klkl.domain.user.domain.User;
 import taco.klkl.domain.user.service.UserService;
 
 @Slf4j
 @RestController
-@RequestMapping("api/v1/users")
+@Tag(name = "1. 유저", description = "유저 관련 API")
+@RequestMapping("/v1/users")
 public class UserController {
 	final UserService userService;
 
@@ -20,6 +23,7 @@ public class UserController {
 		this.userService = userService;
 	}
 
+	@Operation(summary = "내 정보 조회", description = "내 정보를 조회합니다. (테스트용)")
 	@GetMapping("/me")
 	public ResponseEntity<User> getMe() {
 		User user = userService.me();

--- a/src/main/resources/application-h2.yaml
+++ b/src/main/resources/application-h2.yaml
@@ -15,7 +15,13 @@ spring:
     database-platform: org.hibernate.dialect.H2Dialect
     hibernate:
       ddl-auto: create
+    defer-datasource-initialization: true
     properties:
       hibernate:
         show-sql: true
         format-sql: true
+  sql:
+    init:
+      data-locations: classpath:database/data.sql  # 더미데이터 파일 연결
+      mode: always
+      platform: h2

--- a/src/main/resources/database/data.sql
+++ b/src/main/resources/database/data.sql
@@ -1,0 +1,17 @@
+/* User */
+INSERT INTO User(user_id, profile, name, gender, age, description, created_at)
+VALUES (1, 'image/test.jpg', 'testUser', '남', 20, '테스트입니다.', now());
+
+/* Product */
+
+/* Like */
+
+/* Comment */
+
+/* Region */
+
+/* Category */
+
+/* Filter */
+
+/* Notification */

--- a/src/test/java/taco/klkl/domain/user/Integration/UserIntegrationTest.java
+++ b/src/test/java/taco/klkl/domain/user/Integration/UserIntegrationTest.java
@@ -14,7 +14,6 @@ import org.springframework.transaction.annotation.Transactional;
 import taco.klkl.domain.user.dao.UserRepository;
 import taco.klkl.domain.user.domain.User;
 import taco.klkl.domain.user.service.UserService;
-import taco.klkl.global.common.enums.Gender;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -29,19 +28,13 @@ public class UserIntegrationTest {
 	@Autowired
 	UserRepository userRepository;
 
-	User user;
-
 	@Test
 	public void testUserMe() throws Exception {
-		// given
-		User user = new User(null, "testUser", Gender.MALE, 20, "테스트 유저입니다.");
-
-		// when
-		userRepository.save(user);
-		user = userService.me();
+		// given, when
+		User user = userService.me();
 
 		// then
-		mockMvc.perform(get("/api/v1/users/me"))
+		mockMvc.perform(get("/v1/users/me"))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.isSuccess", is(true)))
 			.andExpect(jsonPath("$.code", is("C000")))
@@ -50,7 +43,7 @@ public class UserIntegrationTest {
 			.andExpect(jsonPath("$.data.gender", is(user.getGender().toString())))
 			.andExpect(jsonPath("$.data.age", is(user.getAge())))
 			.andExpect(jsonPath("$.data.description", is(user.getDescription())))
-			.andExpect(jsonPath("$.data.profile", is("image/default.jpg")))
+			.andExpect(jsonPath("$.data.profile", is("image/test.jpg")))
 			.andExpect(jsonPath("$.data.createdAt", notNullValue()))
 			.andExpect(jsonPath("$.timestamp", notNullValue()));
 	}

--- a/src/test/java/taco/klkl/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/taco/klkl/domain/user/controller/UserControllerTest.java
@@ -39,7 +39,7 @@ class UserControllerTest {
 		Mockito.when(userService.me()).thenReturn(user);
 
 		// when & then
-		mockMvc.perform(get("/api/v1/users/me")
+		mockMvc.perform(get("/v1/users/me")
 				.contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.isSuccess", is(true)))


### PR DESCRIPTION
## 📌 연관된 이슈
- **[KL-100/sql 초기실행 설정](https://ohhamma.atlassian.net/browse/KL-100)**

## 📝 작업 내용
- 더미 데이터를 h2에 연결 설정
- 더미 데이터 추가
- User 객체에 swagger 어노테이션 추가

## 🌳 작업 브랜치명
- `KL-100/sql-초기실행-설정`

## 📸 스크린샷 (선택)

## 💬 리뷰 요구사항 (선택)