### PR TITLE
feat(KL-112): create user dto

### DIFF
--- a/src/main/java/taco/klkl/domain/user/controller/UserController.java
+++ b/src/main/java/taco/klkl/domain/user/controller/UserController.java
@@ -1,6 +1,5 @@
 package taco.klkl.domain.user.controller;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -9,7 +8,7 @@ import org.springframework.web.bind.annotation.RestController;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
-import taco.klkl.domain.user.domain.User;
+import taco.klkl.domain.user.dto.response.UserDetailResponseDto;
 import taco.klkl.domain.user.service.UserService;
 
 @Slf4j
@@ -25,8 +24,8 @@ public class UserController {
 
 	@Operation(summary = "내 정보 조회", description = "내 정보를 조회합니다. (테스트용)")
 	@GetMapping("/me")
-	public ResponseEntity<User> getMe() {
-		User user = userService.me();
-		return new ResponseEntity<>(user, HttpStatus.OK);
+	public ResponseEntity<UserDetailResponseDto> getMe() {
+		UserDetailResponseDto userDto = userService.getMyInfo();
+		return ResponseEntity.ok().body(userDto);
 	}
 }

--- a/src/main/java/taco/klkl/domain/user/domain/User.java
+++ b/src/main/java/taco/klkl/domain/user/domain/User.java
@@ -42,18 +42,22 @@ public class User {
 	private LocalDateTime createdAt;
 
 	@PrePersist
-	protected void onCreate() {
+	protected void prePersist() {
 		if (this.profile == null) {
 			this.profile = "image/default.jpg";
 		}
 		this.createdAt = LocalDateTime.now();
 	}
 
-	public User(String profile, String name, Gender gender, Integer age, String description) {
+	private User(String profile, String name, Gender gender, Integer age, String description) {
 		this.profile = profile;
 		this.name = name;
 		this.gender = gender;
 		this.age = age;
 		this.description = description;
+	}
+
+	public static User of(String profile, String name, Gender gender, Integer age, String description) {
+		return new User(profile, name, gender, age, description);
 	}
 }

--- a/src/main/java/taco/klkl/domain/user/domain/User.java
+++ b/src/main/java/taco/klkl/domain/user/domain/User.java
@@ -32,7 +32,7 @@ public class User {
 	private Gender gender;
 
 	@Column(nullable = false)
-	private int age;
+	private Integer age;
 
 	@Column(length = 100)
 	private String description;
@@ -49,7 +49,7 @@ public class User {
 		this.createdAt = LocalDateTime.now();
 	}
 
-	public User(String profile, String name, Gender gender, int age, String description) {
+	public User(String profile, String name, Gender gender, Integer age, String description) {
 		this.profile = profile;
 		this.name = name;
 		this.gender = gender;

--- a/src/main/java/taco/klkl/domain/user/domain/User.java
+++ b/src/main/java/taco/klkl/domain/user/domain/User.java
@@ -56,5 +56,4 @@ public class User {
 		this.age = age;
 		this.description = description;
 	}
-
 }

--- a/src/main/java/taco/klkl/domain/user/dto/request/UserCreateRequestDto.java
+++ b/src/main/java/taco/klkl/domain/user/dto/request/UserCreateRequestDto.java
@@ -1,0 +1,13 @@
+package taco.klkl.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.PositiveOrZero;
+
+public record UserCreateRequestDto(
+	@NotBlank(message = "이름은 필수 항목입니다.") String name,
+	@NotBlank(message = "성별은 필수 항목입니다.") String gender,
+	@PositiveOrZero(message = "나이는 0 이상이어야 합니다.") int age,
+	String profile,
+	String description
+) {
+}

--- a/src/main/java/taco/klkl/domain/user/dto/request/UserCreateRequestDto.java
+++ b/src/main/java/taco/klkl/domain/user/dto/request/UserCreateRequestDto.java
@@ -1,12 +1,12 @@
 package taco.klkl.domain.user.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 
 public record UserCreateRequestDto(
-	@NotBlank(message = "이름은 필수 항목입니다.") String name,
-	@NotBlank(message = "성별은 필수 항목입니다.") String gender,
-	@PositiveOrZero(message = "나이는 0 이상이어야 합니다.") int age,
+	@NotNull(message = "이름은 필수 항목입니다.") String name,
+	@NotNull(message = "성별은 필수 항목입니다.") String gender,
+	@PositiveOrZero(message = "나이는 0 이상이어야 합니다.") Integer age,
 	String profile,
 	String description
 ) {

--- a/src/main/java/taco/klkl/domain/user/dto/response/UserDetailResponseDto.java
+++ b/src/main/java/taco/klkl/domain/user/dto/response/UserDetailResponseDto.java
@@ -1,0 +1,21 @@
+package taco.klkl.domain.user.dto.response;
+
+import taco.klkl.domain.user.domain.User;
+
+public record UserDetailResponseDto(
+	Long id,
+	String profile,
+	String name,
+	String description,
+	int totalLikeCount
+) {
+	public static UserDetailResponseDto from(User user) {
+		return new UserDetailResponseDto(
+			user.getId(),
+			user.getProfile(),
+			user.getName(),
+			user.getDescription(),
+			0
+		);
+	}
+}

--- a/src/main/java/taco/klkl/domain/user/dto/response/UserSimpleResponseDto.java
+++ b/src/main/java/taco/klkl/domain/user/dto/response/UserSimpleResponseDto.java
@@ -1,0 +1,17 @@
+package taco.klkl.domain.user.dto.response;
+
+import taco.klkl.domain.user.domain.User;
+
+public record UserSimpleResponseDto(
+	Long id,
+	String profile,
+	String name
+) {
+	public static UserSimpleResponseDto from(User user) {
+		return new UserSimpleResponseDto(
+			user.getId(),
+			user.getProfile(),
+			user.getName()
+		);
+	}
+}

--- a/src/main/java/taco/klkl/domain/user/service/UserService.java
+++ b/src/main/java/taco/klkl/domain/user/service/UserService.java
@@ -1,34 +1,49 @@
 package taco.klkl.domain.user.service;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import taco.klkl.domain.user.dao.UserRepository;
 import taco.klkl.domain.user.domain.User;
+import taco.klkl.domain.user.dto.request.UserCreateRequestDto;
+import taco.klkl.domain.user.dto.response.UserDetailResponseDto;
+import taco.klkl.global.common.enums.Gender;
 
 @Slf4j
 @Service
 @Transactional
+@RequiredArgsConstructor
 public class UserService {
-	@Autowired
-	UserRepository userRepository;
+	public static final String MY_NAME = "testUser";
+
+	private final UserRepository userRepository;
 
 	/**
 	 * 임시 나의 정보 조회
-	 * Id 1번 유저를 반환합니다.
+	 * name 속성이 "testUser"인 유저를 반환합니다.
 	 */
-	public User me() {
-		return userRepository.findFirstByName("testUser");
+	public UserDetailResponseDto getMyInfo() {
+		User me = userRepository.findFirstByName(MY_NAME);
+		return UserDetailResponseDto.from(me);
 	}
 
 	/**
-	 * @param user user object
-	 * @return Long user_id
+	 *
+	 * @param userDto
+	 * @return UserDetailResponseDto
 	 */
-	public Long join(User user) {
+	public UserDetailResponseDto registerUser(UserCreateRequestDto userDto) {
+		User user = User.of(
+			userDto.profile(),
+			userDto.name(),
+			Gender.getGenderByDescription(userDto.description()),
+			userDto.age(),
+			userDto.description()
+		);
 		userRepository.save(user);
-		return user.getId();
+		return UserDetailResponseDto.from(user);
 	}
+
 }

--- a/src/main/java/taco/klkl/global/common/enums/Gender.java
+++ b/src/main/java/taco/klkl/global/common/enums/Gender.java
@@ -1,5 +1,7 @@
 package taco.klkl.global.common.enums;
 
+import java.util.Arrays;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -7,7 +9,17 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum Gender {
 	MALE("남"),
-	FEMALE("여");
+	FEMALE("여"),
+	NONE(""),
+	;
 
 	private final String description;
+
+	public static Gender getGenderByDescription(String description) {
+		return Arrays.stream(Gender.values())
+			.filter(g -> g.getDescription().equals(description))
+			.findFirst()
+			.orElse(NONE);
+	}
+
 }

--- a/src/test/java/taco/klkl/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/taco/klkl/domain/user/controller/UserControllerTest.java
@@ -5,6 +5,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,6 +15,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import taco.klkl.domain.user.domain.User;
+import taco.klkl.domain.user.dto.response.UserDetailResponseDto;
 import taco.klkl.domain.user.service.UserService;
 import taco.klkl.global.common.enums.Gender;
 
@@ -26,17 +28,19 @@ class UserControllerTest {
 	@MockBean
 	UserService userService;
 
-	private User user;
+	private UserDetailResponseDto responseDto;
 
 	@BeforeEach
 	public void setUp() {
-		user = new User(null, "testUser", Gender.MALE, 20, "테스트 유저입니다.");
+		User user = User.of("image/default.jpg", "testUser", Gender.MALE, 20, "테스트 유저입니다.");
+		responseDto = UserDetailResponseDto.from(user);
 	}
 
 	@Test
-	public void getMe() throws Exception {
+	@DisplayName("내 정보 조회 API 테스트")
+	public void testGetMe() throws Exception {
 		// given
-		Mockito.when(userService.me()).thenReturn(user);
+		Mockito.when(userService.getMyInfo()).thenReturn(responseDto);
 
 		// when & then
 		mockMvc.perform(get("/v1/users/me")
@@ -45,12 +49,10 @@ class UserControllerTest {
 			.andExpect(jsonPath("$.isSuccess", is(true)))
 			.andExpect(jsonPath("$.code", is("C000")))
 			.andExpect(jsonPath("$.data.id", is(nullValue())))
-			.andExpect(jsonPath("$.data.name", is(user.getName())))
-			.andExpect(jsonPath("$.data.gender", is(user.getGender().toString())))
-			.andExpect(jsonPath("$.data.age", is(user.getAge())))
-			.andExpect(jsonPath("$.data.description", is(user.getDescription())))
-			.andExpect(jsonPath("$.data.profile", is(nullValue())))
-			.andExpect(jsonPath("$.data.createdAt", is(nullValue())))
+			.andExpect(jsonPath("$.data.profile", is(notNullValue())))
+			.andExpect(jsonPath("$.data.name", is(responseDto.name())))
+			.andExpect(jsonPath("$.data.description", is(responseDto.description())))
+			.andExpect(jsonPath("$.data.totalLikeCount", is(0)))
 			.andExpect(jsonPath("$.timestamp", notNullValue()));
 	}
 }

--- a/src/test/java/taco/klkl/domain/user/dto/UserDtoTest.java
+++ b/src/test/java/taco/klkl/domain/user/dto/UserDtoTest.java
@@ -35,10 +35,10 @@ class UserDtoTest {
 	}
 
 	@Test
-	@DisplayName("이름이 없는 UserCreateRequestDto 유효성 검사")
+	@DisplayName("이름이 null인 UserCreateRequestDto 유효성 검사")
 	public void testInvalidUserCreateRequestDto_NameRequired() {
 		// given
-		UserCreateRequestDto requestDto = new UserCreateRequestDto("", "남", 20, "image/profile.png", "자기소개");
+		UserCreateRequestDto requestDto = new UserCreateRequestDto(null, "남", 20, "image/profile.png", "자기소개");
 
 		// when
 		Set<ConstraintViolation<UserCreateRequestDto>> violations = validator.validate(requestDto);

--- a/src/test/java/taco/klkl/domain/user/dto/UserDtoTest.java
+++ b/src/test/java/taco/klkl/domain/user/dto/UserDtoTest.java
@@ -1,0 +1,62 @@
+package taco.klkl.domain.user.dto;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import taco.klkl.domain.user.dto.request.UserCreateRequestDto;
+
+class UserDtoTest {
+	private final Validator validator;
+
+	public UserDtoTest() {
+		ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+		this.validator = factory.getValidator();
+	}
+
+	@Test
+	@DisplayName("유효한 UserCreateRequestDto에 대한 유효성 검사")
+	public void testValidUserCreateRequestDto() {
+		// given
+		UserCreateRequestDto requestDto = new UserCreateRequestDto("이름", "남", 20, "image/profile.png", "자기소개");
+
+		// when
+		Set<ConstraintViolation<UserCreateRequestDto>> violations = validator.validate(requestDto);
+
+		// then
+		assertThat(violations).isEmpty();
+	}
+
+	@Test
+	@DisplayName("이름이 없는 UserCreateRequestDto 유효성 검사")
+	public void testInvalidUserCreateRequestDto_NameRequired() {
+		// given
+		UserCreateRequestDto requestDto = new UserCreateRequestDto("", "남", 20, "image/profile.png", "자기소개");
+
+		// when
+		Set<ConstraintViolation<UserCreateRequestDto>> violations = validator.validate(requestDto);
+
+		// then
+		assertThat(violations).isNotEmpty();
+	}
+
+	@Test
+	@DisplayName("나이가 음수인 UserCreateRequestDto 유효성 검사")
+	public void testInvalidUserCreateRequestDto_AgeNegative() {
+		// given
+		UserCreateRequestDto requestDto = new UserCreateRequestDto("이름", "남", -1, "image/profile.png", "자기소개");
+
+		// when
+		Set<ConstraintViolation<UserCreateRequestDto>> violations = validator.validate(requestDto);
+
+		// then
+		assertThat(violations).isNotEmpty();
+	}
+}

--- a/src/test/java/taco/klkl/domain/user/dto/request/UserRequestDtoTest.java
+++ b/src/test/java/taco/klkl/domain/user/dto/request/UserRequestDtoTest.java
@@ -1,4 +1,4 @@
-package taco.klkl.domain.user.dto;
+package taco.klkl.domain.user.dto.request;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -11,12 +11,11 @@ import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import jakarta.validation.ValidatorFactory;
-import taco.klkl.domain.user.dto.request.UserCreateRequestDto;
 
-class UserDtoTest {
+class UserRequestDtoTest {
 	private final Validator validator;
 
-	public UserDtoTest() {
+	public UserRequestDtoTest() {
 		ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
 		this.validator = factory.getValidator();
 	}

--- a/src/test/java/taco/klkl/domain/user/dto/response/UserDetailResponseDtoTest.java
+++ b/src/test/java/taco/klkl/domain/user/dto/response/UserDetailResponseDtoTest.java
@@ -41,7 +41,7 @@ public class UserDetailResponseDtoTest {
 		String description = "자기소개";
 
 		// when
-		User user = new User(profile, name, gender, age, description);
+		User user = User.of(profile, name, gender, age, description);
 		UserDetailResponseDto userDetail = UserDetailResponseDto.from(user);
 
 		// then

--- a/src/test/java/taco/klkl/domain/user/dto/response/UserDetailResponseDtoTest.java
+++ b/src/test/java/taco/klkl/domain/user/dto/response/UserDetailResponseDtoTest.java
@@ -1,0 +1,53 @@
+package taco.klkl.domain.user.dto.response;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import taco.klkl.domain.user.domain.User;
+import taco.klkl.global.common.enums.Gender;
+
+public class UserDetailResponseDtoTest {
+	@Test
+	@DisplayName("유저 상세 정보를 반환하는 DTO 테스트")
+	public void testUserDetailResponseDto() {
+		// given
+		Long id = 1L;
+		String profile = "image/profile.png";
+		String name = "이름";
+		String description = "자기소개";
+		int totalLikeCount = 100;
+
+		// when
+		UserDetailResponseDto userDetail = new UserDetailResponseDto(id, profile, name, description, totalLikeCount);
+
+		// then
+		assertThat(userDetail.id()).isEqualTo(id);
+		assertThat(userDetail.profile()).isEqualTo(profile);
+		assertThat(userDetail.name()).isEqualTo(name);
+		assertThat(userDetail.description()).isEqualTo(description);
+		assertThat(userDetail.totalLikeCount()).isEqualTo(totalLikeCount);
+	}
+
+	@Test
+	@DisplayName("User 객체로부터 UserDetailResponseDto 생성 테스트")
+	public void testFrom() {
+		// given
+		String profile = "image/profile.png";
+		String name = "이름";
+		Gender gender = Gender.MALE;
+		int age = 20;
+		String description = "자기소개";
+
+		// when
+		User user = new User(profile, name, gender, age, description);
+		UserDetailResponseDto userDetail = UserDetailResponseDto.from(user);
+
+		// then
+		assertThat(userDetail.profile()).isEqualTo(profile);
+		assertThat(userDetail.name()).isEqualTo(name);
+		assertThat(userDetail.description()).isEqualTo(description);
+		assertThat(userDetail.totalLikeCount()).isEqualTo(0);
+	}
+}

--- a/src/test/java/taco/klkl/domain/user/dto/response/UserSimpleResponseDtoTest.java
+++ b/src/test/java/taco/klkl/domain/user/dto/response/UserSimpleResponseDtoTest.java
@@ -37,7 +37,7 @@ class UserSimpleResponseDtoTest {
 		String description = "자기소개";
 
 		// when
-		User user = new User(profile, name, gender, age, description);
+		User user = User.of(profile, name, gender, age, description);
 		UserSimpleResponseDto userSimple = UserSimpleResponseDto.from(user);
 
 		// then

--- a/src/test/java/taco/klkl/domain/user/dto/response/UserSimpleResponseDtoTest.java
+++ b/src/test/java/taco/klkl/domain/user/dto/response/UserSimpleResponseDtoTest.java
@@ -1,0 +1,47 @@
+package taco.klkl.domain.user.dto.response;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import taco.klkl.domain.user.domain.User;
+import taco.klkl.global.common.enums.Gender;
+
+class UserSimpleResponseDtoTest {
+	@Test
+	@DisplayName("유저 간단 정보를 반환하는 DTO 테스트")
+	public void testUserSimpleResponseDto() {
+		// given
+		Long id = 1L;
+		String profile = "image/profile.png";
+		String name = "이름";
+
+		// when
+		UserSimpleResponseDto userSimple = new UserSimpleResponseDto(id, profile, name);
+
+		// then
+		assertThat(userSimple.id()).isEqualTo(id);
+		assertThat(userSimple.profile()).isEqualTo(profile);
+		assertThat(userSimple.name()).isEqualTo(name);
+	}
+
+	@Test
+	@DisplayName("User 객체로부터 UserSimpleResponseDto 생성 테스트")
+	public void testFrom() {
+		// given
+		String profile = "image/profile.png";
+		String name = "이름";
+		Gender gender = Gender.MALE;
+		int age = 20;
+		String description = "자기소개";
+
+		// when
+		User user = new User(profile, name, gender, age, description);
+		UserSimpleResponseDto userSimple = UserSimpleResponseDto.from(user);
+
+		// then
+		assertThat(userSimple.profile()).isEqualTo(profile);
+		assertThat(userSimple.name()).isEqualTo(name);
+	}
+}

--- a/src/test/java/taco/klkl/domain/user/integration/UserIntegrationTest.java
+++ b/src/test/java/taco/klkl/domain/user/integration/UserIntegrationTest.java
@@ -12,7 +12,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
 import taco.klkl.domain.user.dao.UserRepository;
-import taco.klkl.domain.user.domain.User;
+import taco.klkl.domain.user.dto.response.UserDetailResponseDto;
 import taco.klkl.domain.user.service.UserService;
 
 @SpringBootTest
@@ -31,20 +31,18 @@ public class UserIntegrationTest {
 	@Test
 	public void testUserMe() throws Exception {
 		// given, when
-		User user = userService.me();
+		UserDetailResponseDto userDto = userService.getMyInfo();
 
 		// then
 		mockMvc.perform(get("/v1/users/me"))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.isSuccess", is(true)))
 			.andExpect(jsonPath("$.code", is("C000")))
-			.andExpect(jsonPath("$.data.id", is(user.getId().intValue())))
-			.andExpect(jsonPath("$.data.name", is(user.getName())))
-			.andExpect(jsonPath("$.data.gender", is(user.getGender().toString())))
-			.andExpect(jsonPath("$.data.age", is(user.getAge())))
-			.andExpect(jsonPath("$.data.description", is(user.getDescription())))
-			.andExpect(jsonPath("$.data.profile", is("image/test.jpg")))
-			.andExpect(jsonPath("$.data.createdAt", notNullValue()))
-			.andExpect(jsonPath("$.timestamp", notNullValue()));
+			.andExpect(jsonPath("$.data.id", is(userDto.id().intValue())))
+			.andExpect(jsonPath("$.data.profile", is(userDto.profile())))
+			.andExpect(jsonPath("$.data.name", is(userDto.name())))
+			.andExpect(jsonPath("$.data.description", is(userDto.description())))
+			.andExpect(jsonPath("$.timestamp", notNullValue()))
+		;
 	}
 }


### PR DESCRIPTION
## 📌 연관된 이슈
- **[KL-112/User DTO 구현](https://ohhamma.atlassian.net/browse/KL-112)**

## 📝 작업 내용
- UserDTO 생성 및 테스트 : `UserCreateRequestDto`, `UserDetailResponseDto`, `UserSimpleResponseDto`
- `UserService`, `UserController`에 UserDTO 적용 및 테스트
- `User` 엔티티에 정적 팩토리 메서드 적용

## 🌳 작업 브랜치명
- `KL-112/user-dto-구현`

## 📸 스크린샷 (선택)

## 💬 리뷰 요구사항 (선택)