### PR TITLE
feat(KL-118): region api

### DIFF
--- a/src/main/java/taco/klkl/domain/region/controller/RegionController.java
+++ b/src/main/java/taco/klkl/domain/region/controller/RegionController.java
@@ -1,0 +1,35 @@
+package taco.klkl.domain.region.controller;
+
+import java.util.List;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import taco.klkl.domain.region.dto.response.RegionResponseDto;
+import taco.klkl.domain.region.service.RegionService;
+
+@Slf4j
+@RestController
+@RequestMapping("/v1/regions")
+@RequiredArgsConstructor
+@Tag(name = "5. 지역", description = "지역 관련 API")
+public class RegionController {
+	private final RegionService regionService;
+
+	@Operation(summary = "모든 지역 조회", description = "모든 지역을 조회합니다.")
+	@GetMapping()
+	public ResponseEntity<List<RegionResponseDto>> getAllRegions() {
+		List<RegionResponseDto> regionResponseDtos = regionService.getAllRegions();
+
+		return ResponseEntity.ok()
+			.contentType(MediaType.APPLICATION_JSON)
+			.body(regionResponseDtos);
+	}
+}

--- a/src/main/java/taco/klkl/domain/region/dao/RegionRepository.java
+++ b/src/main/java/taco/klkl/domain/region/dao/RegionRepository.java
@@ -1,0 +1,15 @@
+package taco.klkl.domain.region.dao;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import taco.klkl.domain.region.domain.Region;
+
+@Repository
+public interface RegionRepository extends JpaRepository<Region, Long> {
+	Region findFirstByName(String name);
+
+	List<Region> findAllByOrderByRegionIdAsc();
+}

--- a/src/main/java/taco/klkl/domain/region/dao/RegionRepository.java
+++ b/src/main/java/taco/klkl/domain/region/dao/RegionRepository.java
@@ -6,10 +6,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import taco.klkl.domain.region.domain.Region;
+import taco.klkl.domain.region.enums.RegionType;
 
 @Repository
 public interface RegionRepository extends JpaRepository<Region, Long> {
-	Region findFirstByName(String name);
+	Region findFirstByName(RegionType name);
 
 	List<Region> findAllByOrderByRegionIdAsc();
 }

--- a/src/main/java/taco/klkl/domain/region/domain/Region.java
+++ b/src/main/java/taco/klkl/domain/region/domain/Region.java
@@ -26,7 +26,7 @@ public class Region {
 		this.name = name;
 	}
 
-	public Region of(String name) {
+	public static Region of(String name) {
 		return new Region(name);
 	}
 }

--- a/src/main/java/taco/klkl/domain/region/domain/Region.java
+++ b/src/main/java/taco/klkl/domain/region/domain/Region.java
@@ -1,0 +1,32 @@
+package taco.klkl.domain.region.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Region {
+
+	@Id
+	@Column(name = "region_id")
+	@GeneratedValue(strategy = GenerationType.AUTO)
+	Long regionId;
+
+	@Column(name = "name", length = 20, nullable = false)
+	String name;
+
+	private Region(String name) {
+		this.name = name;
+	}
+
+	public Region of(String name) {
+		return new Region(name);
+	}
+}

--- a/src/main/java/taco/klkl/domain/region/domain/Region.java
+++ b/src/main/java/taco/klkl/domain/region/domain/Region.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import taco.klkl.domain.region.enums.RegionType;
 
 @Getter
 @Entity
@@ -20,13 +21,13 @@ public class Region {
 	Long regionId;
 
 	@Column(name = "name", length = 20, nullable = false)
-	String name;
+	RegionType name;
 
-	private Region(String name) {
-		this.name = name;
+	private Region(RegionType region) {
+		this.name = region;
 	}
 
-	public static Region of(String name) {
-		return new Region(name);
+	public static Region of(RegionType regionType) {
+		return new Region(regionType);
 	}
 }

--- a/src/main/java/taco/klkl/domain/region/dto/response/RegionResponseDto.java
+++ b/src/main/java/taco/klkl/domain/region/dto/response/RegionResponseDto.java
@@ -1,0 +1,13 @@
+package taco.klkl.domain.region.dto.response;
+
+import taco.klkl.domain.region.domain.Region;
+
+public record RegionResponseDto(
+	Long regionId,
+	String name
+) {
+
+	public static RegionResponseDto from(Region region) {
+		return new RegionResponseDto(region.getRegionId(), region.getName());
+	}
+}

--- a/src/main/java/taco/klkl/domain/region/dto/response/RegionResponseDto.java
+++ b/src/main/java/taco/klkl/domain/region/dto/response/RegionResponseDto.java
@@ -8,6 +8,6 @@ public record RegionResponseDto(
 ) {
 
 	public static RegionResponseDto from(Region region) {
-		return new RegionResponseDto(region.getRegionId(), region.getName());
+		return new RegionResponseDto(region.getRegionId(), region.getName().getName());
 	}
 }

--- a/src/main/java/taco/klkl/domain/region/enums/RegionType.java
+++ b/src/main/java/taco/klkl/domain/region/enums/RegionType.java
@@ -1,0 +1,24 @@
+package taco.klkl.domain.region.enums;
+
+import java.util.Arrays;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum RegionType {
+	NORTHEAST_ASIA("동북아시아"),
+	SOUTHEAST_ASIA("동남아시아"),
+	ETC_REGION("기타"),
+	NONE("");
+
+	private final String name;
+
+	public static RegionType getRegionByName(String regionName) {
+		return Arrays.stream(RegionType.values())
+			.filter(r -> r.getName().equals(regionName))
+			.findFirst()
+			.orElse(NONE);
+	}
+}

--- a/src/main/java/taco/klkl/domain/region/enums/RegionTypeConvert.java
+++ b/src/main/java/taco/klkl/domain/region/enums/RegionTypeConvert.java
@@ -1,0 +1,28 @@
+package taco.klkl.domain.region.enums;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = true)
+public class RegionTypeConvert implements AttributeConverter<RegionType, String> {
+
+	@Override
+	public String convertToDatabaseColumn(RegionType regionType) {
+		if (regionType == null) {
+			return null;
+		}
+
+		return regionType.getName();
+	}
+
+	@Override
+	public RegionType convertToEntityAttribute(String dbData) {
+		RegionType regionType = RegionType.getRegionByName(dbData);
+
+		if (regionType.equals(RegionType.NONE)) {
+			throw new IllegalArgumentException("Unknown value: " + dbData);
+		}
+
+		return regionType;
+	}
+}

--- a/src/main/java/taco/klkl/domain/region/exception/RegionNotFoundException.java
+++ b/src/main/java/taco/klkl/domain/region/exception/RegionNotFoundException.java
@@ -1,0 +1,10 @@
+package taco.klkl.domain.region.exception;
+
+import taco.klkl.global.error.exception.CustomException;
+import taco.klkl.global.error.exception.ErrorCode;
+
+public class RegionNotFoundException extends CustomException {
+	public RegionNotFoundException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+}

--- a/src/main/java/taco/klkl/domain/region/exception/RegionNotFoundException.java
+++ b/src/main/java/taco/klkl/domain/region/exception/RegionNotFoundException.java
@@ -4,7 +4,7 @@ import taco.klkl.global.error.exception.CustomException;
 import taco.klkl.global.error.exception.ErrorCode;
 
 public class RegionNotFoundException extends CustomException {
-	public RegionNotFoundException(ErrorCode errorCode) {
-		super(errorCode);
+	public RegionNotFoundException() {
+		super(ErrorCode.REGION_NOT_FOUND);
 	}
 }

--- a/src/main/java/taco/klkl/domain/region/service/RegionService.java
+++ b/src/main/java/taco/klkl/domain/region/service/RegionService.java
@@ -1,0 +1,16 @@
+package taco.klkl.domain.region.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import taco.klkl.domain.region.dto.response.RegionResponseDto;
+
+@Service
+public interface RegionService {
+	public List<RegionResponseDto> getAllRegions();
+
+	public RegionResponseDto getRegionById(Long id);
+
+	public RegionResponseDto getRegionByName(String name);
+}

--- a/src/main/java/taco/klkl/domain/region/service/RegionServiceImpl.java
+++ b/src/main/java/taco/klkl/domain/region/service/RegionServiceImpl.java
@@ -1,0 +1,50 @@
+package taco.klkl.domain.region.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import taco.klkl.domain.region.dao.RegionRepository;
+import taco.klkl.domain.region.domain.Region;
+import taco.klkl.domain.region.dto.response.RegionResponseDto;
+import taco.klkl.domain.region.exception.RegionNotFoundException;
+import taco.klkl.global.error.exception.ErrorCode;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class RegionServiceImpl implements RegionService {
+
+	private final RegionRepository regionRepository;
+
+	@Override
+	public List<RegionResponseDto> getAllRegions() {
+		List<Region> regions = regionRepository.findAllByOrderByRegionIdAsc();
+		return regions.stream()
+			.map(RegionResponseDto::from)
+			.toList();
+	}
+
+	@Override
+	public RegionResponseDto getRegionById(Long id) {
+		Region region = regionRepository.findById(id)
+			.orElseThrow(() -> new RegionNotFoundException(ErrorCode.REGION_NOT_FOUND));
+		
+		return RegionResponseDto.from(region);
+	}
+
+	@Override
+	public RegionResponseDto getRegionByName(String name) {
+		Region region = regionRepository.findFirstByName(name);
+
+		if (region == null) {
+			throw new RegionNotFoundException(ErrorCode.REGION_NOT_FOUND);
+		}
+
+		return RegionResponseDto.from(region);
+	}
+}

--- a/src/main/java/taco/klkl/domain/region/service/RegionServiceImpl.java
+++ b/src/main/java/taco/klkl/domain/region/service/RegionServiceImpl.java
@@ -12,6 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 import taco.klkl.domain.region.dao.RegionRepository;
 import taco.klkl.domain.region.domain.Region;
 import taco.klkl.domain.region.dto.response.RegionResponseDto;
+import taco.klkl.domain.region.enums.RegionType;
 import taco.klkl.domain.region.exception.RegionNotFoundException;
 
 @Slf4j
@@ -45,7 +46,7 @@ public class RegionServiceImpl implements RegionService {
 
 	@Override
 	public RegionResponseDto getRegionByName(String name) throws RegionNotFoundException {
-		Region region = regionRepository.findFirstByName(name);
+		Region region = regionRepository.findFirstByName(RegionType.getRegionByName(name));
 
 		if (region == null) {
 			throw new RegionNotFoundException();

--- a/src/main/java/taco/klkl/domain/region/service/RegionServiceImpl.java
+++ b/src/main/java/taco/klkl/domain/region/service/RegionServiceImpl.java
@@ -1,7 +1,9 @@
 package taco.klkl.domain.region.service;
 
+import java.util.Collections;
 import java.util.List;
 
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,9 +13,9 @@ import taco.klkl.domain.region.dao.RegionRepository;
 import taco.klkl.domain.region.domain.Region;
 import taco.klkl.domain.region.dto.response.RegionResponseDto;
 import taco.klkl.domain.region.exception.RegionNotFoundException;
-import taco.klkl.global.error.exception.ErrorCode;
 
 @Slf4j
+@Primary
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -24,25 +26,29 @@ public class RegionServiceImpl implements RegionService {
 	@Override
 	public List<RegionResponseDto> getAllRegions() {
 		List<Region> regions = regionRepository.findAllByOrderByRegionIdAsc();
+
+		if (regions == null) {
+			return Collections.emptyList();
+		}
+
 		return regions.stream()
 			.map(RegionResponseDto::from)
 			.toList();
 	}
 
 	@Override
-	public RegionResponseDto getRegionById(Long id) {
+	public RegionResponseDto getRegionById(Long id) throws RegionNotFoundException {
 		Region region = regionRepository.findById(id)
-			.orElseThrow(() -> new RegionNotFoundException(ErrorCode.REGION_NOT_FOUND));
-		
+			.orElseThrow(RegionNotFoundException::new);
 		return RegionResponseDto.from(region);
 	}
 
 	@Override
-	public RegionResponseDto getRegionByName(String name) {
+	public RegionResponseDto getRegionByName(String name) throws RegionNotFoundException {
 		Region region = regionRepository.findFirstByName(name);
 
 		if (region == null) {
-			throw new RegionNotFoundException(ErrorCode.REGION_NOT_FOUND);
+			throw new RegionNotFoundException();
 		}
 
 		return RegionResponseDto.from(region);

--- a/src/main/java/taco/klkl/global/error/exception/ErrorCode.java
+++ b/src/main/java/taco/klkl/global/error/exception/ErrorCode.java
@@ -22,7 +22,7 @@ public enum ErrorCode {
 	// Comment
 
 	// Region
-	REGION_NOT_FOUND(HttpStatus.NOT_FOUND, "C060", "해당 지역을 찾을 수 없습니다."),
+	REGION_NOT_FOUND(HttpStatus.NOT_FOUND, "C050", "해당 지역을 찾을 수 없습니다."),
 
 	// Category
 

--- a/src/main/java/taco/klkl/global/error/exception/ErrorCode.java
+++ b/src/main/java/taco/klkl/global/error/exception/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
 	// Comment
 
 	// Region
+	REGION_NOT_FOUND(HttpStatus.NOT_FOUND, "C060", "해당 지역을 찾을 수 없습니다."),
 
 	// Category
 

--- a/src/main/resources/application-h2.yaml
+++ b/src/main/resources/application-h2.yaml
@@ -4,6 +4,8 @@ spring:
     console:
       enabled: true  # H2 Console을 사용할지 여부 (H2 Console은 H2 Database를 UI로 제공해주는 기능)
       path: /h2-console  # H2 Console의 Path
+      settings:
+        web-allow-others: true
   # Database Setting Info (Database를 H2로 사용하기 위해 H2연결 정보 입력)
   datasource:
     driver-class-name: org.h2.Driver

--- a/src/main/resources/database/data.sql
+++ b/src/main/resources/database/data.sql
@@ -9,9 +9,14 @@ VALUES (1, 'image/test.jpg', 'testUser', '남', 20, '테스트입니다.', now()
 /* Comment */
 
 /* Region */
+INSERT INTO Region(region_id, name)
+VALUES (400, '동북아시아'),
+       (401, '동남아시아'),
+       (402, '기타');
 
 /* Category */
-INSERT INTO Category(category_id, name)
+INSERT
+INTO Category(category_id, name)
 VALUES (300, '식품'),
        (301, '의류'),
        (302, '잡화'),

--- a/src/test/java/taco/klkl/domain/region/controller/RegionControllerTest.java
+++ b/src/test/java/taco/klkl/domain/region/controller/RegionControllerTest.java
@@ -1,0 +1,100 @@
+package taco.klkl.domain.region.controller;
+
+import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import taco.klkl.domain.region.domain.Region;
+import taco.klkl.domain.region.dto.response.RegionResponseDto;
+import taco.klkl.domain.region.service.RegionService;
+import taco.klkl.global.error.exception.ErrorCode;
+
+@WebMvcTest(RegionController.class)
+class RegionControllerTest {
+
+	@Autowired
+	MockMvc mockMvc;
+
+	@MockBean
+	RegionService regionService;
+
+	@Test
+	@DisplayName("모든 지역 조회 성공 테스트")
+	void getAllRegionsTest() throws Exception {
+		// given
+		String region1Name = "동북아시아";
+		String region2Name = "동남아시아";
+		String region3Name = "기타";
+		List<RegionResponseDto> regionResponseDtos = Arrays.asList(
+			RegionResponseDto.from(Region.of(region1Name)),
+			RegionResponseDto.from(Region.of(region2Name)),
+			RegionResponseDto.from(Region.of(region3Name))
+		);
+
+		when(regionService.getAllRegions()).thenReturn(regionResponseDtos);
+
+		// when & then
+		mockMvc.perform(get("/v1/regions")
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.isSuccess", is(true)))
+			.andExpect(jsonPath("$.code", is("C000")))
+			.andExpect(jsonPath("$.data", hasSize(3)))
+			.andExpect(jsonPath("$.data[0].name", is(region1Name)))
+			.andExpect(jsonPath("$.data[1].name", is(region2Name)))
+			.andExpect(jsonPath("$.data[2].name", is(region3Name)))
+			.andExpect(jsonPath("$.timestamp", notNullValue()));
+
+		verify(regionService, times(1)).getAllRegions();
+	}
+
+	@Test
+	@DisplayName("모든 지역 조회 empty 테스트")
+	void getAllRegionsEmptyTest() throws Exception {
+		// given
+		when(regionService.getAllRegions()).thenReturn(Collections.emptyList());
+
+		// when & then
+		mockMvc.perform(get("/v1/regions")
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.isSuccess", is(true)))
+			.andExpect(jsonPath("$.code", is("C000")))
+			.andExpect(jsonPath("$.data", hasSize(0)))
+			.andExpect(jsonPath("$.timestamp", notNullValue()));
+
+		verify(regionService, times(1)).getAllRegions();
+	}
+
+	@Test
+	@DisplayName("모든 지역 조회 실패 테스트")
+	void getRegionsFailTest() throws Exception {
+		// given
+		when(regionService.getAllRegions()).thenThrow(RuntimeException.class);
+
+		// when & then
+		mockMvc.perform(get("/v1/regions")
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().is5xxServerError())
+			.andExpect(jsonPath("$.isSuccess", is(false)))
+			.andExpect(jsonPath("$.code", is(ErrorCode.INTERNAL_SERVER_ERROR.getCode())))
+			.andExpect(jsonPath("$.data.message", is(ErrorCode.INTERNAL_SERVER_ERROR.getMessage())))
+			.andExpect(jsonPath("$.timestamp", notNullValue()));
+
+		verify(regionService, times(1)).getAllRegions();
+	}
+
+}

--- a/src/test/java/taco/klkl/domain/region/controller/RegionControllerTest.java
+++ b/src/test/java/taco/klkl/domain/region/controller/RegionControllerTest.java
@@ -19,6 +19,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import taco.klkl.domain.region.domain.Region;
 import taco.klkl.domain.region.dto.response.RegionResponseDto;
+import taco.klkl.domain.region.enums.RegionType;
 import taco.klkl.domain.region.service.RegionService;
 import taco.klkl.global.error.exception.ErrorCode;
 
@@ -35,13 +36,10 @@ class RegionControllerTest {
 	@DisplayName("모든 지역 조회 성공 테스트")
 	void getAllRegionsTest() throws Exception {
 		// given
-		String region1Name = "동북아시아";
-		String region2Name = "동남아시아";
-		String region3Name = "기타";
 		List<RegionResponseDto> regionResponseDtos = Arrays.asList(
-			RegionResponseDto.from(Region.of(region1Name)),
-			RegionResponseDto.from(Region.of(region2Name)),
-			RegionResponseDto.from(Region.of(region3Name))
+			RegionResponseDto.from(Region.of(RegionType.NORTHEAST_ASIA)),
+			RegionResponseDto.from(Region.of(RegionType.SOUTHEAST_ASIA)),
+			RegionResponseDto.from(Region.of(RegionType.ETC_REGION))
 		);
 
 		when(regionService.getAllRegions()).thenReturn(regionResponseDtos);
@@ -53,9 +51,9 @@ class RegionControllerTest {
 			.andExpect(jsonPath("$.isSuccess", is(true)))
 			.andExpect(jsonPath("$.code", is("C000")))
 			.andExpect(jsonPath("$.data", hasSize(3)))
-			.andExpect(jsonPath("$.data[0].name", is(region1Name)))
-			.andExpect(jsonPath("$.data[1].name", is(region2Name)))
-			.andExpect(jsonPath("$.data[2].name", is(region3Name)))
+			.andExpect(jsonPath("$.data[0].name", is(RegionType.NORTHEAST_ASIA.getName())))
+			.andExpect(jsonPath("$.data[1].name", is(RegionType.SOUTHEAST_ASIA.getName())))
+			.andExpect(jsonPath("$.data[2].name", is(RegionType.ETC_REGION.getName())))
 			.andExpect(jsonPath("$.timestamp", notNullValue()));
 
 		verify(regionService, times(1)).getAllRegions();

--- a/src/test/java/taco/klkl/domain/region/integration/RegionIntegrationTest.java
+++ b/src/test/java/taco/klkl/domain/region/integration/RegionIntegrationTest.java
@@ -1,0 +1,46 @@
+package taco.klkl.domain.region.integration;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import jakarta.transaction.Transactional;
+import taco.klkl.domain.region.dto.response.RegionResponseDto;
+import taco.klkl.domain.region.service.RegionService;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class RegionIntegrationTest {
+
+	@Autowired
+	MockMvc mockMvc;
+
+	@Autowired
+	RegionService regionService;
+
+	@Test
+	@DisplayName("모든 지역 조회 통합 테스트")
+	void getAllRegionsTest() throws Exception {
+		// given
+		List<RegionResponseDto> regionResponseDtos = regionService.getAllRegions();
+
+		// when & then
+		mockMvc.perform(get("/v1/regions")
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code", is("C000")))
+			.andExpect(jsonPath("$.isSuccess", is(true)))
+			.andExpect(jsonPath("$.data", hasSize(regionResponseDtos.size())));
+	}
+}

--- a/src/test/java/taco/klkl/domain/region/service/RegionServiceImplTest.java
+++ b/src/test/java/taco/klkl/domain/region/service/RegionServiceImplTest.java
@@ -1,0 +1,127 @@
+package taco.klkl.domain.region.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import taco.klkl.domain.region.dao.RegionRepository;
+import taco.klkl.domain.region.domain.Region;
+import taco.klkl.domain.region.dto.response.RegionResponseDto;
+import taco.klkl.domain.region.exception.RegionNotFoundException;
+
+@ExtendWith(MockitoExtension.class)
+class RegionServiceImplTest {
+
+	@InjectMocks
+	RegionServiceImpl regionService;
+
+	@Mock
+	RegionRepository regionRepository;
+
+	private static final Region region1 = Region.of("동북아시아");
+	private static final Region region2 = Region.of("동남아시아");
+	private static final Region region3 = Region.of("기타");
+
+	@Test
+	@DisplayName("모든 지역 조회 성공 테스트")
+	void getAllRegionTest() {
+		// given
+		List<Region> mockRegions = Arrays.asList(region1, region2, region3);
+
+		when(regionRepository.findAllByOrderByRegionIdAsc()).thenReturn(mockRegions);
+
+		// when
+		List<RegionResponseDto> regionResponseDtos = regionService.getAllRegions();
+
+		// then
+		assertThat(regionResponseDtos.size()).isEqualTo(3);
+		assertThat(regionResponseDtos.get(0).name()).isEqualTo(region1.getName());
+		assertThat(regionResponseDtos.get(1).name()).isEqualTo(region2.getName());
+		assertThat(regionResponseDtos.get(2).name()).isEqualTo(region3.getName());
+	}
+
+	@Test
+	@DisplayName("모든 지역 조회 실패 테스트")
+	void getAllRegionFailTest() {
+		// given
+		when(regionRepository.findAllByOrderByRegionIdAsc()).thenReturn(Collections.emptyList());
+
+		// when
+		List<RegionResponseDto> regionResponseDtos = regionService.getAllRegions();
+
+		// then
+		assertThat(regionResponseDtos.size()).isEqualTo(0);
+	}
+
+	@Test
+	@DisplayName("Id 지역 조회 성공 테스트")
+	void getRegionById() {
+		// given
+		when(regionRepository.findById(1L)).thenReturn(Optional.of(region1));
+		when(regionRepository.findById(2L)).thenReturn(Optional.of(region2));
+
+		// when
+		RegionResponseDto region1ResponseDto = regionService.getRegionById(1L);
+		RegionResponseDto region2ResponseDto = regionService.getRegionById(2L);
+
+		// then
+		assertThat(region1ResponseDto.name()).isEqualTo(region1.getName());
+		assertThat(region2ResponseDto.name()).isEqualTo(region2.getName());
+	}
+
+	@Test
+	@DisplayName("Id 지역 조회 실패 테스트")
+	void getRegionByIdFailTest() {
+		// given
+		when(regionRepository.findById(1L)).thenThrow(new RegionNotFoundException());
+
+		// when & then
+		Assertions.assertThrows(RegionNotFoundException.class, () -> {
+			regionService.getRegionById(1L);
+		});
+
+		verify(regionRepository, times(1)).findById(1L);
+	}
+
+	@Test
+	@DisplayName("Name 지역 조회 성공 테스트")
+	void getRegionByNameTest() {
+		// given
+		when(regionRepository.findFirstByName(region1.getName())).thenReturn(region1);
+		when(regionRepository.findFirstByName(region2.getName())).thenReturn(region2);
+
+		// when
+		RegionResponseDto region1ResponseDto = regionService.getRegionByName(region1.getName());
+		RegionResponseDto region2ResponseDto = regionService.getRegionByName(region2.getName());
+
+		// then
+		assertThat(region1ResponseDto.name()).isEqualTo(region1.getName());
+		assertThat(region2ResponseDto.name()).isEqualTo(region2.getName());
+	}
+
+	@Test
+	@DisplayName("Name 지역 조회 실패 테스트")
+	void getRegionByNameFailTest() {
+		// given
+		when(regionRepository.findFirstByName(region1.getName())).thenThrow(new RegionNotFoundException());
+
+		// when & then
+		Assertions.assertThrows(RegionNotFoundException.class, () -> {
+			regionService.getRegionByName(region1.getName());
+		});
+
+		verify(regionRepository, times(1)).findFirstByName(region1.getName());
+	}
+}

--- a/src/test/java/taco/klkl/domain/region/service/RegionServiceImplTest.java
+++ b/src/test/java/taco/klkl/domain/region/service/RegionServiceImplTest.java
@@ -19,6 +19,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import taco.klkl.domain.region.dao.RegionRepository;
 import taco.klkl.domain.region.domain.Region;
 import taco.klkl.domain.region.dto.response.RegionResponseDto;
+import taco.klkl.domain.region.enums.RegionType;
 import taco.klkl.domain.region.exception.RegionNotFoundException;
 
 @ExtendWith(MockitoExtension.class)
@@ -30,9 +31,9 @@ class RegionServiceImplTest {
 	@Mock
 	RegionRepository regionRepository;
 
-	private static final Region region1 = Region.of("동북아시아");
-	private static final Region region2 = Region.of("동남아시아");
-	private static final Region region3 = Region.of("기타");
+	private static final Region region1 = Region.of(RegionType.NORTHEAST_ASIA);
+	private static final Region region2 = Region.of(RegionType.SOUTHEAST_ASIA);
+	private static final Region region3 = Region.of(RegionType.ETC_REGION);
 
 	@Test
 	@DisplayName("모든 지역 조회 성공 테스트")
@@ -47,9 +48,9 @@ class RegionServiceImplTest {
 
 		// then
 		assertThat(regionResponseDtos.size()).isEqualTo(3);
-		assertThat(regionResponseDtos.get(0).name()).isEqualTo(region1.getName());
-		assertThat(regionResponseDtos.get(1).name()).isEqualTo(region2.getName());
-		assertThat(regionResponseDtos.get(2).name()).isEqualTo(region3.getName());
+		assertThat(regionResponseDtos.get(0).name()).isEqualTo(region1.getName().getName());
+		assertThat(regionResponseDtos.get(1).name()).isEqualTo(region2.getName().getName());
+		assertThat(regionResponseDtos.get(2).name()).isEqualTo(region3.getName().getName());
 	}
 
 	@Test
@@ -77,8 +78,8 @@ class RegionServiceImplTest {
 		RegionResponseDto region2ResponseDto = regionService.getRegionById(2L);
 
 		// then
-		assertThat(region1ResponseDto.name()).isEqualTo(region1.getName());
-		assertThat(region2ResponseDto.name()).isEqualTo(region2.getName());
+		assertThat(region1ResponseDto.name()).isEqualTo(region1.getName().getName());
+		assertThat(region2ResponseDto.name()).isEqualTo(region2.getName().getName());
 	}
 
 	@Test
@@ -103,12 +104,12 @@ class RegionServiceImplTest {
 		when(regionRepository.findFirstByName(region2.getName())).thenReturn(region2);
 
 		// when
-		RegionResponseDto region1ResponseDto = regionService.getRegionByName(region1.getName());
-		RegionResponseDto region2ResponseDto = regionService.getRegionByName(region2.getName());
+		RegionResponseDto region1ResponseDto = regionService.getRegionByName(region1.getName().getName());
+		RegionResponseDto region2ResponseDto = regionService.getRegionByName(region2.getName().getName());
 
 		// then
-		assertThat(region1ResponseDto.name()).isEqualTo(region1.getName());
-		assertThat(region2ResponseDto.name()).isEqualTo(region2.getName());
+		assertThat(region1ResponseDto.name()).isEqualTo(region1.getName().getName());
+		assertThat(region2ResponseDto.name()).isEqualTo(region2.getName().getName());
 	}
 
 	@Test
@@ -119,7 +120,7 @@ class RegionServiceImplTest {
 
 		// when & then
 		Assertions.assertThrows(RegionNotFoundException.class, () -> {
-			regionService.getRegionByName(region1.getName());
+			regionService.getRegionByName(region1.getName().getName());
 		});
 
 		verify(regionRepository, times(1)).findFirstByName(region1.getName());


### PR DESCRIPTION
## 📌 연관된 이슈
[KL-118/지역 API 구현](https://ohhamma.atlassian.net/browse/KL-118)

## 📝 작업 내용
- "동북아시아", "동남아시아", "기타" 지역 조회 가능
- `/v1/regions` 엔드포인트 구현
- RegionType Enum 추가

## 🌳 작업 브랜치명
**KL-118/지역-api-구현**

## 📸 스크린샷 (선택)

## 💬 리뷰 요구사항 (선택)
