### PR TITLE
feat(KL-111): add Product controller

### DIFF
--- a/src/main/java/taco/klkl/domain/product/controller/ProductController.java
+++ b/src/main/java/taco/klkl/domain/product/controller/ProductController.java
@@ -1,0 +1,40 @@
+package taco.klkl.domain.product.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import taco.klkl.domain.product.dto.request.ProductCreateRequestDto;
+import taco.klkl.domain.product.dto.response.ProductDetailResponseDto;
+import taco.klkl.domain.product.service.ProductService;
+
+@RestController
+@RequestMapping("/v1/products")
+@Tag(name = "2. 상품", description = "상품 관련 API")
+@RequiredArgsConstructor
+public class ProductController {
+
+	private final ProductService productService;
+
+	@GetMapping("/{id}")
+	@Operation(summary = "상품 상세 조회", description = "상품 상세 정보를 조회합니다.")
+	public ResponseEntity<ProductDetailResponseDto> getProductInfoById(@PathVariable Long id) {
+		ProductDetailResponseDto productDto = productService.getProductInfoById(id);
+		return ResponseEntity.ok().body(productDto);
+	}
+
+	@PostMapping
+	@Operation(summary = "상품 등록", description = "상품을 등록합니다.")
+	public ResponseEntity<ProductDetailResponseDto> createProduct(@RequestBody ProductCreateRequestDto createRequest) {
+		ProductDetailResponseDto productDto = productService.createProduct(createRequest);
+		return ResponseEntity.status(HttpStatus.CREATED).body(productDto);
+	}
+}

--- a/src/main/resources/database/data.sql
+++ b/src/main/resources/database/data.sql
@@ -3,6 +3,9 @@ INSERT INTO User(user_id, profile, name, gender, age, description, created_at)
 VALUES (1, 'image/test.jpg', 'testUser', '남', 20, '테스트입니다.', now());
 
 /* Product */
+INSERT INTO Product(product_id, user_id, name, description, address, price, city_id, subcategory_id, currency_id,
+                    created_at)
+VALUES (1, 1, '곤약젤리', '탱글탱글 맛있는 곤약젤리', '신사이바시 메가돈키호테', 1000, 2, 3, 4, now());
 
 /* Like */
 
@@ -11,7 +14,8 @@ VALUES (1, 'image/test.jpg', 'testUser', '남', 20, '테스트입니다.', now()
 /* Region */
 
 /* Category */
-INSERT INTO Category(category_id, name)
+INSERT
+INTO Category(category_id, name)
 VALUES (300, '식품'),
        (301, '의류'),
        (302, '잡화'),

--- a/src/test/java/taco/klkl/domain/product/controller/ProductControllerTest.java
+++ b/src/test/java/taco/klkl/domain/product/controller/ProductControllerTest.java
@@ -1,0 +1,128 @@
+package taco.klkl.domain.product.controller;
+
+import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import taco.klkl.domain.product.domain.Product;
+import taco.klkl.domain.product.dto.request.ProductCreateRequestDto;
+import taco.klkl.domain.product.dto.response.ProductDetailResponseDto;
+import taco.klkl.domain.product.service.ProductService;
+import taco.klkl.domain.user.domain.User;
+
+@WebMvcTest(ProductController.class)
+class ProductControllerTest {
+
+	@Autowired
+	MockMvc mockMvc;
+
+	@MockBean
+	ProductService productService;
+
+	@Autowired
+	ObjectMapper objectMapper;
+
+	private ProductDetailResponseDto productDetailResponseDto;
+	private ProductCreateRequestDto productCreateRequestDto;
+
+	@BeforeEach
+	public void setUp() {
+		// Mock User 객체 생성
+		User mockUser = mock(User.class);
+		when(mockUser.getId()).thenReturn(1L);
+
+		// Mock Product 객체 생성
+		Product mockProduct = mock(Product.class);
+		when(mockProduct.getProductId()).thenReturn(1L);
+		when(mockProduct.getUser()).thenReturn(mockUser);
+		when(mockProduct.getName()).thenReturn("name");
+		when(mockProduct.getDescription()).thenReturn("description");
+		when(mockProduct.getAddress()).thenReturn("address");
+		when(mockProduct.getLikeCount()).thenReturn(0);
+		when(mockProduct.getCreatedAt()).thenReturn(LocalDateTime.now());
+		when(mockProduct.getPrice()).thenReturn(1000);
+		when(mockProduct.getCityId()).thenReturn(2L);
+		when(mockProduct.getSubcategoryId()).thenReturn(3L);
+		when(mockProduct.getCurrencyId()).thenReturn(4L);
+
+		// ProductDetailResponseDto 생성
+		productDetailResponseDto = ProductDetailResponseDto.from(mockProduct);
+
+		// ProductCreateRequestDto 생성
+		productCreateRequestDto = new ProductCreateRequestDto(
+			"name",
+			"description",
+			2L,
+			3L,
+			4L,
+			"address",
+			1000
+		);
+	}
+
+	@Test
+	@DisplayName("상품 상세 조회 API 테스트")
+	public void testGetProductInfoById() throws Exception {
+		// given
+		when(productService.getProductInfoById(1L)).thenReturn(productDetailResponseDto);
+
+		// when & then
+		mockMvc.perform(get("/v1/products/1")
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.isSuccess", is(true)))
+			.andExpect(jsonPath("$.code", is("C000")))
+			.andExpect(jsonPath("$.data.productId", is(productDetailResponseDto.productId().intValue())))
+			.andExpect(jsonPath("$.data.userId", is(productDetailResponseDto.userId().intValue())))
+			.andExpect(jsonPath("$.data.name", is(productDetailResponseDto.name())))
+			.andExpect(jsonPath("$.data.description", is(productDetailResponseDto.description())))
+			.andExpect(jsonPath("$.data.address", is(productDetailResponseDto.address())))
+			.andExpect(jsonPath("$.data.likeCount", is(productDetailResponseDto.likeCount())))
+			.andExpect(jsonPath("$.data.price", is(productDetailResponseDto.price())))
+			.andExpect(jsonPath("$.data.cityId", is(productDetailResponseDto.cityId().intValue())))
+			.andExpect(jsonPath("$.data.subcategoryId", is(productDetailResponseDto.subcategoryId().intValue())))
+			.andExpect(jsonPath("$.data.currencyId", is(productDetailResponseDto.currencyId().intValue())))
+			.andExpect(jsonPath("$.timestamp", notNullValue()));
+	}
+
+	@Test
+	@DisplayName("상품 등록 API 테스트")
+	public void testCreateProduct() throws Exception {
+		// given
+		when(productService.createProduct(any(ProductCreateRequestDto.class))).thenReturn(productDetailResponseDto);
+
+		// when & then
+		mockMvc.perform(post("/v1/products")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(productCreateRequestDto)))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.isSuccess", is(true)))
+			.andExpect(jsonPath("$.code", is("C000")))
+			.andExpect(jsonPath("$.data.productId", is(productDetailResponseDto.productId().intValue())))
+			.andExpect(jsonPath("$.data.userId", is(productDetailResponseDto.userId().intValue())))
+			.andExpect(jsonPath("$.data.name", is(productDetailResponseDto.name())))
+			.andExpect(jsonPath("$.data.description", is(productDetailResponseDto.description())))
+			.andExpect(jsonPath("$.data.address", is(productDetailResponseDto.address())))
+			.andExpect(jsonPath("$.data.likeCount", is(productDetailResponseDto.likeCount())))
+			.andExpect(jsonPath("$.data.price", is(productDetailResponseDto.price())))
+			.andExpect(jsonPath("$.data.cityId", is(productDetailResponseDto.cityId().intValue())))
+			.andExpect(jsonPath("$.data.subcategoryId", is(productDetailResponseDto.subcategoryId().intValue())))
+			.andExpect(jsonPath("$.data.currencyId", is(productDetailResponseDto.currencyId().intValue())))
+			.andExpect(jsonPath("$.timestamp", notNullValue()));
+	}
+}

--- a/src/test/java/taco/klkl/domain/product/integration/ProductIntegrationTest.java
+++ b/src/test/java/taco/klkl/domain/product/integration/ProductIntegrationTest.java
@@ -1,0 +1,103 @@
+package taco.klkl.domain.product.integration;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import taco.klkl.domain.product.dao.ProductRepository;
+import taco.klkl.domain.product.dto.request.ProductCreateRequestDto;
+import taco.klkl.domain.product.dto.response.ProductDetailResponseDto;
+import taco.klkl.domain.product.service.ProductService;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@DisplayName("Product 통합 테스트")
+public class ProductIntegrationTest {
+
+	@Autowired
+	MockMvc mockMvc;
+
+	@Autowired
+	ProductService productService;
+
+	@Autowired
+	ProductRepository productRepository;
+
+	@Test
+	@DisplayName("상품 상세 조회 API 테스트")
+	public void testGetProductById() throws Exception {
+		// given
+		ProductCreateRequestDto createDto = new ProductCreateRequestDto(
+			"name",
+			"description",
+			2L,
+			3L,
+			4L,
+			"address",
+			1000
+		);
+		ProductDetailResponseDto productDto = productService.createProduct(createDto);
+
+		// when & then
+		mockMvc.perform(get("/v1/products/" + productDto.productId())
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.isSuccess", is(true)))
+			.andExpect(jsonPath("$.code", is("C000")))
+			.andExpect(jsonPath("$.data.productId", is(productDto.productId().intValue())))
+			.andExpect(jsonPath("$.data.userId", is(productDto.userId().intValue())))
+			.andExpect(jsonPath("$.data.name", is(productDto.name())))
+			.andExpect(jsonPath("$.data.description", is(productDto.description())))
+			.andExpect(jsonPath("$.data.address", is(productDto.address())))
+			.andExpect(jsonPath("$.data.price", is(productDto.price())))
+			.andExpect(jsonPath("$.data.cityId", is(productDto.cityId().intValue())))
+			.andExpect(jsonPath("$.data.subcategoryId", is(productDto.subcategoryId().intValue())))
+			.andExpect(jsonPath("$.data.currencyId", is(productDto.currencyId().intValue())))
+			.andExpect(jsonPath("$.timestamp", notNullValue()));
+	}
+
+	@Test
+	@DisplayName("상품 등록 API 테스트")
+	public void testCreateProduct() throws Exception {
+		// given
+		ProductCreateRequestDto createDto = new ProductCreateRequestDto(
+			"name",
+			"description",
+			2L,
+			3L,
+			4L,
+			"address",
+			1000
+		);
+
+		// when & then
+		mockMvc.perform(post("/v1/products")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(new ObjectMapper().writeValueAsString(createDto)))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.isSuccess", is(true)))
+			.andExpect(jsonPath("$.code", is("C000")))
+			.andExpect(jsonPath("$.data.productId", notNullValue()))
+			.andExpect(jsonPath("$.data.userId", notNullValue()))
+			.andExpect(jsonPath("$.data.name", is(createDto.name())))
+			.andExpect(jsonPath("$.data.description", is(createDto.description())))
+			.andExpect(jsonPath("$.data.address", is(createDto.address())))
+			.andExpect(jsonPath("$.data.price", is(createDto.price())))
+			.andExpect(jsonPath("$.data.cityId", is(createDto.cityId().intValue())))
+			.andExpect(jsonPath("$.data.subcategoryId", is(createDto.subcategoryId().intValue())))
+			.andExpect(jsonPath("$.data.currencyId", is(createDto.currencyId().intValue())))
+			.andExpect(jsonPath("$.timestamp", notNullValue()));
+	}
+}


### PR DESCRIPTION
## 📌 연관된 이슈
- **[KL-111/상품 controller 구현](https://ohhamma.atlassian.net/browse/KL-111)**

## 📝 작업 내용
- 상품 더미 데이터 추가
- ProductController 작성
  - 상품 상세 조회 API 구현
  - 상품 등록 API 구현
- 상품 컨트롤러, 통합 테스트코드 작성

## 🌳 작업 브랜치명
- `KL-111/상품-controller-구현`

## 📸 스크린샷 (선택)

## 💬 리뷰 요구사항 (선택)