### PR TITLE
feat(KL-68): update Product API

### DIFF
--- a/src/main/java/taco/klkl/domain/product/controller/ProductController.java
+++ b/src/main/java/taco/klkl/domain/product/controller/ProductController.java
@@ -47,7 +47,7 @@ public class ProductController {
 	@Operation(summary = "상품 정보 수정", description = "상품 정보를 수정합니다.")
 	public ResponseEntity<ProductDetailResponseDto> updateProduct(
 		@PathVariable Long id,
-		@RequestBody ProductUpdateRequestDto updateRequest
+		@Valid @RequestBody ProductUpdateRequestDto updateRequest
 	) {
 		ProductDetailResponseDto productDto = productService.updateProduct(id, updateRequest);
 		return ResponseEntity.ok().body(productDto);

--- a/src/main/java/taco/klkl/domain/product/controller/ProductController.java
+++ b/src/main/java/taco/klkl/domain/product/controller/ProductController.java
@@ -3,6 +3,7 @@ package taco.klkl.domain.product.controller;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -13,6 +14,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import taco.klkl.domain.product.dto.request.ProductCreateRequestDto;
+import taco.klkl.domain.product.dto.request.ProductUpdateRequestDto;
 import taco.klkl.domain.product.dto.response.ProductDetailResponseDto;
 import taco.klkl.domain.product.service.ProductService;
 
@@ -36,5 +38,15 @@ public class ProductController {
 	public ResponseEntity<ProductDetailResponseDto> createProduct(@RequestBody ProductCreateRequestDto createRequest) {
 		ProductDetailResponseDto productDto = productService.createProduct(createRequest);
 		return ResponseEntity.status(HttpStatus.CREATED).body(productDto);
+	}
+
+	@PatchMapping("/{id}")
+	@Operation(summary = "상품 정보 수정", description = "상품 정보를 수정합니다.")
+	public ResponseEntity<ProductDetailResponseDto> updateProduct(
+		@PathVariable Long id,
+		@RequestBody ProductUpdateRequestDto updateRequest
+	) {
+		ProductDetailResponseDto productDto = productService.updateProduct(id, updateRequest);
+		return ResponseEntity.ok().body(productDto);
 	}
 }

--- a/src/main/java/taco/klkl/domain/product/controller/ProductController.java
+++ b/src/main/java/taco/klkl/domain/product/controller/ProductController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import taco.klkl.domain.product.dto.request.ProductCreateRequestDto;
 import taco.klkl.domain.product.dto.request.ProductUpdateRequestDto;
@@ -35,7 +36,9 @@ public class ProductController {
 
 	@PostMapping
 	@Operation(summary = "상품 등록", description = "상품을 등록합니다.")
-	public ResponseEntity<ProductDetailResponseDto> createProduct(@RequestBody ProductCreateRequestDto createRequest) {
+	public ResponseEntity<ProductDetailResponseDto> createProduct(
+		@Valid @RequestBody ProductCreateRequestDto createRequest
+	) {
 		ProductDetailResponseDto productDto = productService.createProduct(createRequest);
 		return ResponseEntity.status(HttpStatus.CREATED).body(productDto);
 	}

--- a/src/main/java/taco/klkl/domain/product/domain/Product.java
+++ b/src/main/java/taco/klkl/domain/product/domain/Product.java
@@ -16,6 +16,7 @@ import jakarta.persistence.PrePersist;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import taco.klkl.domain.product.dto.request.ProductUpdateRequestDto;
 import taco.klkl.domain.user.domain.User;
 import taco.klkl.global.common.constants.DefaultConstants;
 import taco.klkl.global.common.constants.ProductConstants;
@@ -108,5 +109,29 @@ public class Product {
 		final Long currencyId
 	) {
 		return new Product(user, name, description, address, price, cityId, subcategoryId, currencyId);
+	}
+
+	public void update(ProductUpdateRequestDto updateDto) {
+		if (updateDto.name() != null) {
+			this.name = updateDto.name();
+		}
+		if (updateDto.description() != null) {
+			this.description = updateDto.description();
+		}
+		if (updateDto.address() != null) {
+			this.address = updateDto.address();
+		}
+		if (updateDto.price() != null) {
+			this.price = updateDto.price();
+		}
+		if (updateDto.cityId() != null) {
+			this.cityId = updateDto.cityId();
+		}
+		if (updateDto.subcategoryId() != null) {
+			this.subcategoryId = updateDto.subcategoryId();
+		}
+		if (updateDto.currencyId() != null) {
+			this.currencyId = updateDto.currencyId();
+		}
 	}
 }

--- a/src/main/java/taco/klkl/domain/product/domain/Product.java
+++ b/src/main/java/taco/klkl/domain/product/domain/Product.java
@@ -36,34 +36,62 @@ public class Product {
 	@JoinColumn(name = "user_id")
 	private User user;
 
-	@Column(name = "name", length = 100, nullable = false)
+	@Column(
+		name = "name",
+		length = ProductConstants.NAME_MAX_LENGTH,
+		nullable = false
+	)
 	private String name;
 
-	@Column(name = "description", length = 2000, nullable = false)
+	@Column(
+		name = "description",
+		length = ProductConstants.DESCRIPTION_MAX_LENGTH,
+		nullable = false
+	)
 	private String description;
 
-	@Column(name = "address", length = 100)
+	@Column(
+		name = "address",
+		length = ProductConstants.ADDRESS_MAX_LENGTH,
+		nullable = false
+	)
 	@ColumnDefault(DefaultConstants.DEFAULT_STRING)
 	private String address;
 
-	@Column(name = "like_count", nullable = false)
+	@Column(
+		name = "like_count",
+		nullable = false
+	)
 	@ColumnDefault(DefaultConstants.DEFAULT_INT_STRING)
 	private Integer likeCount;
 
-	@Column(name = "created_at", nullable = false, updatable = false)
+	@Column(
+		name = "created_at",
+		nullable = false,
+		updatable = false
+	)
 	private LocalDateTime createdAt;
 
 	@Column(name = "price")
 	@ColumnDefault(DefaultConstants.DEFAULT_INT_STRING)
 	private Integer price;
 
-	@Column(name = "city_id", nullable = false)
+	@Column(
+		name = "city_id",
+		nullable = false
+	)
 	private Long cityId;
 
-	@Column(name = "subcategory_id", nullable = false)
+	@Column(
+		name = "subcategory_id",
+		nullable = false
+	)
 	private Long subcategoryId;
 
-	@Column(name = "currency_id", nullable = false)
+	@Column(
+		name = "currency_id",
+		nullable = false
+	)
 	private Long currencyId;
 
 	@PrePersist

--- a/src/main/java/taco/klkl/domain/product/dto/request/ProductCreateRequestDto.java
+++ b/src/main/java/taco/klkl/domain/product/dto/request/ProductCreateRequestDto.java
@@ -1,26 +1,41 @@
 package taco.klkl.domain.product.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import taco.klkl.global.common.constants.ProductConstants;
 
 /**
  * TODO: 상품필터속성 추가 해야함 (상품필터속성 테이블 개발 후)
  * TODO: 상품 컨트롤러에서 필터 서비스를 이용해서 조합 하는게 괜찮아 보입니다.
  * @param name
  * @param description
+ * @param address
+ * @param price
  * @param cityId
  * @param subcategoryId
  * @param currencyId
- * @param price
- * @param address
  */
 public record ProductCreateRequestDto(
-	@NotNull(message = "상품명은 필수 항목입니다.") String name,
-	@NotNull(message = "상품 설명은 필수 항목입니다.") String description,
+	@NotNull(message = "상품명은 필수 항목입니다.")
+	@NotBlank(message = "상품명은 비어있을 수 없습니다.")
+	@Size(max = ProductConstants.NAME_MAX_LENGTH, message = "상품명은 100자 이하여야 합니다.")
+	String name,
+
+	@NotNull(message = "상품 설명은 필수 항목입니다.")
+	@NotBlank(message = "상품 설명은 비어있을 수 없습니다.")
+	@Size(max = ProductConstants.DESCRIPTION_MAX_LENGTH, message = "상품 설명은 2000자 이하여야 합니다.")
+	String description,
+
+	@Size(max = ProductConstants.ADDRESS_MAX_LENGTH, message = "주소는 100자 이하여야 합니다.")
+	String address,
+
+	@PositiveOrZero(message = "가격은 0 이상이어야 합니다.")
+	Integer price,
+
 	@NotNull(message = "도시 ID는 필수 항목입니다.") Long cityId,
 	@NotNull(message = "상품 소분류 ID은 필수 항목입니다.") Long subcategoryId,
-	@NotNull(message = "통화 ID는 필수 항목입니다.") Long currencyId,
-	@PositiveOrZero(message = "가격은 0 이상이어야 합니다.") Integer price,
-	String address
+	@NotNull(message = "통화 ID는 필수 항목입니다.") Long currencyId
 ) {
 }

--- a/src/main/java/taco/klkl/domain/product/dto/request/ProductCreateRequestDto.java
+++ b/src/main/java/taco/klkl/domain/product/dto/request/ProductCreateRequestDto.java
@@ -1,6 +1,7 @@
 package taco.klkl.domain.product.dto.request;
 
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
 
 /**
  * TODO: 상품필터속성 추가 해야함 (상품필터속성 테이블 개발 후)
@@ -10,8 +11,8 @@ import jakarta.validation.constraints.NotNull;
  * @param cityId
  * @param subcategoryId
  * @param currencyId
- * @param address
  * @param price
+ * @param address
  */
 public record ProductCreateRequestDto(
 	@NotNull(message = "상품명은 필수 항목입니다.") String name,
@@ -19,7 +20,7 @@ public record ProductCreateRequestDto(
 	@NotNull(message = "도시 ID는 필수 항목입니다.") Long cityId,
 	@NotNull(message = "상품 소분류 ID은 필수 항목입니다.") Long subcategoryId,
 	@NotNull(message = "통화 ID는 필수 항목입니다.") Long currencyId,
-	String address,
-	Integer price
+	@PositiveOrZero(message = "가격은 0 이상이어야 합니다.") Integer price,
+	String address
 ) {
 }

--- a/src/main/java/taco/klkl/domain/product/dto/request/ProductCreateRequestDto.java
+++ b/src/main/java/taco/klkl/domain/product/dto/request/ProductCreateRequestDto.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
 import taco.klkl.global.common.constants.ProductConstants;
+import taco.klkl.global.common.constants.ProductValidationMessages;
 
 /**
  * TODO: 상품필터속성 추가 해야함 (상품필터속성 테이블 개발 후)
@@ -18,24 +19,29 @@ import taco.klkl.global.common.constants.ProductConstants;
  * @param currencyId
  */
 public record ProductCreateRequestDto(
-	@NotNull(message = "상품명은 필수 항목입니다.")
-	@NotBlank(message = "상품명은 비어있을 수 없습니다.")
-	@Size(max = ProductConstants.NAME_MAX_LENGTH, message = "상품명은 100자 이하여야 합니다.")
+	@NotNull(message = ProductValidationMessages.NAME_NOT_NULL)
+	@NotBlank(message = ProductValidationMessages.NAME_NOT_BLANK)
+	@Size(max = ProductConstants.NAME_MAX_LENGTH, message = ProductValidationMessages.NAME_SIZE)
 	String name,
 
-	@NotNull(message = "상품 설명은 필수 항목입니다.")
-	@NotBlank(message = "상품 설명은 비어있을 수 없습니다.")
-	@Size(max = ProductConstants.DESCRIPTION_MAX_LENGTH, message = "상품 설명은 2000자 이하여야 합니다.")
+	@NotNull(message = ProductValidationMessages.DESCRIPTION_NOT_NULL)
+	@NotBlank(message = ProductValidationMessages.DESCRIPTION_NOT_BLANK)
+	@Size(max = ProductConstants.DESCRIPTION_MAX_LENGTH, message = ProductValidationMessages.DESCRIPTION_SIZE)
 	String description,
 
-	@Size(max = ProductConstants.ADDRESS_MAX_LENGTH, message = "주소는 100자 이하여야 합니다.")
+	@Size(max = ProductConstants.ADDRESS_MAX_LENGTH, message = ProductValidationMessages.ADDRESS_SIZE)
 	String address,
 
-	@PositiveOrZero(message = "가격은 0 이상이어야 합니다.")
+	@PositiveOrZero(message = ProductValidationMessages.PRICE_POSITIVE_OR_ZERO)
 	Integer price,
 
-	@NotNull(message = "도시 ID는 필수 항목입니다.") Long cityId,
-	@NotNull(message = "상품 소분류 ID은 필수 항목입니다.") Long subcategoryId,
-	@NotNull(message = "통화 ID는 필수 항목입니다.") Long currencyId
+	@NotNull(message = ProductValidationMessages.CITY_ID_NOT_NULL)
+	Long cityId,
+
+	@NotNull(message = ProductValidationMessages.SUBCATEGORY_ID_NOT_NULL)
+	Long subcategoryId,
+
+	@NotNull(message = ProductValidationMessages.CURRENCY_ID_NOT_NULL)
+	Long currencyId
 ) {
 }

--- a/src/main/java/taco/klkl/domain/product/dto/request/ProductUpdateRequestDto.java
+++ b/src/main/java/taco/klkl/domain/product/dto/request/ProductUpdateRequestDto.java
@@ -1,12 +1,28 @@
 package taco.klkl.domain.product.dto.request;
 
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import taco.klkl.global.common.constants.ProductConstants;
+import taco.klkl.global.common.constants.ProductValidationMessages;
+
 public record ProductUpdateRequestDto(
+	@Size(max = ProductConstants.NAME_MAX_LENGTH, message = ProductValidationMessages.NAME_SIZE)
 	String name,
+
+	@Size(max = ProductConstants.DESCRIPTION_MAX_LENGTH, message = ProductValidationMessages.DESCRIPTION_SIZE)
 	String description,
-	Long cityId,
-	Long subcategoryId,
-	Long currencyId,
+
+	@Size(max = ProductConstants.ADDRESS_MAX_LENGTH, message = ProductValidationMessages.ADDRESS_SIZE)
 	String address,
-	Integer price
+
+	@PositiveOrZero(message = ProductValidationMessages.PRICE_POSITIVE_OR_ZERO)
+	Integer price,
+
+	Long cityId,
+
+	Long subcategoryId,
+
+	Long currencyId
+
 ) {
 }

--- a/src/main/java/taco/klkl/domain/product/service/ProductService.java
+++ b/src/main/java/taco/klkl/domain/product/service/ProductService.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import taco.klkl.domain.product.dao.ProductRepository;
 import taco.klkl.domain.product.domain.Product;
 import taco.klkl.domain.product.dto.request.ProductCreateRequestDto;
+import taco.klkl.domain.product.dto.request.ProductUpdateRequestDto;
 import taco.klkl.domain.product.dto.response.ProductDetailResponseDto;
 import taco.klkl.domain.product.exception.ProductNotFoundException;
 import taco.klkl.domain.user.domain.User;
@@ -20,8 +21,8 @@ public class ProductService {
 	private final ProductRepository productRepository;
 	private final UserUtil userUtil;
 
-	public ProductDetailResponseDto getProductInfoById(Long id) {
-		Product product = productRepository.findById(id)
+	public ProductDetailResponseDto getProductInfoById(final Long id) {
+		final Product product = productRepository.findById(id)
 			.orElseThrow(ProductNotFoundException::new);
 		return ProductDetailResponseDto.from(product);
 	}
@@ -30,6 +31,14 @@ public class ProductService {
 		final Product product = createProductEntity(productDto);
 		productRepository.save(product);
 		return ProductDetailResponseDto.from(product);
+	}
+
+	public ProductDetailResponseDto updateProduct(final Long id, final ProductUpdateRequestDto productDto) {
+		final Product product = productRepository.findById(id)
+			.orElseThrow(ProductNotFoundException::new);
+		product.update(productDto);
+		final Product updatedProduct = productRepository.save(product);
+		return ProductDetailResponseDto.from(updatedProduct);
 	}
 
 	private Product createProductEntity(final ProductCreateRequestDto productDto) {

--- a/src/main/java/taco/klkl/domain/product/service/ProductService.java
+++ b/src/main/java/taco/klkl/domain/product/service/ProductService.java
@@ -40,8 +40,7 @@ public class ProductService {
 		final Product product = productRepository.findById(id)
 			.orElseThrow(ProductNotFoundException::new);
 		product.update(productDto);
-		final Product updatedProduct = productRepository.save(product);
-		return ProductDetailResponseDto.from(updatedProduct);
+		return ProductDetailResponseDto.from(product);
 	}
 
 	private Product createProductEntity(final ProductCreateRequestDto productDto) {

--- a/src/main/java/taco/klkl/domain/product/service/ProductService.java
+++ b/src/main/java/taco/klkl/domain/product/service/ProductService.java
@@ -11,10 +11,11 @@ import taco.klkl.domain.product.dto.request.ProductUpdateRequestDto;
 import taco.klkl.domain.product.dto.response.ProductDetailResponseDto;
 import taco.klkl.domain.product.exception.ProductNotFoundException;
 import taco.klkl.domain.user.domain.User;
+import taco.klkl.global.common.constants.ProductConstants;
 import taco.klkl.global.util.UserUtil;
 
 @Service
-@Transactional
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class ProductService {
 
@@ -27,12 +28,14 @@ public class ProductService {
 		return ProductDetailResponseDto.from(product);
 	}
 
+	@Transactional
 	public ProductDetailResponseDto createProduct(final ProductCreateRequestDto productDto) {
 		final Product product = createProductEntity(productDto);
 		productRepository.save(product);
 		return ProductDetailResponseDto.from(product);
 	}
 
+	@Transactional
 	public ProductDetailResponseDto updateProduct(final Long id, final ProductUpdateRequestDto productDto) {
 		final Product product = productRepository.findById(id)
 			.orElseThrow(ProductNotFoundException::new);
@@ -54,5 +57,4 @@ public class ProductService {
 			productDto.currencyId()
 		);
 	}
-
 }

--- a/src/main/java/taco/klkl/global/common/constants/DefaultConstants.java
+++ b/src/main/java/taco/klkl/global/common/constants/DefaultConstants.java
@@ -1,6 +1,6 @@
 package taco.klkl.global.common.constants;
 
-public class DefaultConstants {
+public final class DefaultConstants {
 
 	public static final String DEFAULT_STRING = "'N/A'";
 	public static final String DEFAULT_INT_STRING = "0";

--- a/src/main/java/taco/klkl/global/common/constants/ProductConstants.java
+++ b/src/main/java/taco/klkl/global/common/constants/ProductConstants.java
@@ -6,6 +6,10 @@ public class ProductConstants {
 	public static final int DEFAULT_LIKE_COUNT = 0;
 	public static final String DEFAULT_ADDRESS = "N/A";
 
+	public static final int NAME_MAX_LENGTH = 100;
+	public static final int DESCRIPTION_MAX_LENGTH = 2000;
+	public static final int ADDRESS_MAX_LENGTH = 100;
+
 	private ProductConstants() {
 	}
 }

--- a/src/main/java/taco/klkl/global/common/constants/ProductConstants.java
+++ b/src/main/java/taco/klkl/global/common/constants/ProductConstants.java
@@ -1,6 +1,6 @@
 package taco.klkl.global.common.constants;
 
-public class ProductConstants {
+public final class ProductConstants {
 
 	public static final int DEFAULT_PRICE = 0;
 	public static final int DEFAULT_LIKE_COUNT = 0;

--- a/src/main/java/taco/klkl/global/common/constants/ProductValidationMessages.java
+++ b/src/main/java/taco/klkl/global/common/constants/ProductValidationMessages.java
@@ -1,0 +1,23 @@
+package taco.klkl.global.common.constants;
+
+public final class ProductValidationMessages {
+
+	public static final String NAME_NOT_NULL = "상품명은 필수 항목입니다.";
+	public static final String NAME_NOT_BLANK = "상품명은 비어있을 수 없습니다.";
+	public static final String NAME_SIZE = "상품명은 100자 이하여야 합니다.";
+
+	public static final String DESCRIPTION_NOT_NULL = "상품 설명은 필수 항목입니다.";
+	public static final String DESCRIPTION_NOT_BLANK = "상품 설명은 비어있을 수 없습니다.";
+	public static final String DESCRIPTION_SIZE = "상품 설명은 2000자 이하여야 합니다.";
+
+	public static final String ADDRESS_SIZE = "주소는 100자 이하여야 합니다.";
+
+	public static final String PRICE_POSITIVE_OR_ZERO = "가격은 0 이상이어야 합니다.";
+
+	public static final String CITY_ID_NOT_NULL = "도시 ID는 필수 항목입니다.";
+	public static final String SUBCATEGORY_ID_NOT_NULL = "상품 소분류 ID는 필수 항목입니다.";
+	public static final String CURRENCY_ID_NOT_NULL = "통화 ID는 필수 항목입니다.";
+
+	private ProductValidationMessages() {
+	}
+}

--- a/src/main/java/taco/klkl/global/common/constants/UserConstants.java
+++ b/src/main/java/taco/klkl/global/common/constants/UserConstants.java
@@ -3,7 +3,7 @@ package taco.klkl.global.common.constants;
 import taco.klkl.domain.user.domain.User;
 import taco.klkl.global.common.enums.Gender;
 
-public class UserConstants {
+public final class UserConstants {
 
 	public static final String TEST_USER_NAME = "testUser";
 	public static final User TEST_USER = User.of(

--- a/src/main/java/taco/klkl/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/taco/klkl/global/error/GlobalExceptionHandler.java
@@ -103,7 +103,6 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 		return ResponseEntity.status(errorCode.getStatus()).body(globalResponse);
 	}
 
-	// TODO: json 문법 오류 있으면 BAD_REQUEST 반환
 	@ExceptionHandler(Exception.class)
 	public ResponseEntity<Object> handleException(Exception ex) {
 		log.error("InternalServerError : {}", ex.getMessage(), ex);

--- a/src/main/java/taco/klkl/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/taco/klkl/global/error/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -74,6 +75,20 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 	) {
 		log.error("ExceptionInternal : {}", ex.getMessage(), ex);
 		final ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
+		final ErrorResponse errorResponse = ErrorResponse.of(errorCode.getCode(), errorCode.getMessage());
+		final GlobalResponse globalResponse = GlobalResponse.error(errorCode.getCode(), errorResponse);
+		return ResponseEntity.status(errorCode.getStatus()).body(globalResponse);
+	}
+
+	@Override
+	protected ResponseEntity<Object> handleHttpMessageNotReadable(
+		HttpMessageNotReadableException ex,
+		HttpHeaders headers,
+		HttpStatusCode status,
+		WebRequest request
+	) {
+		log.error("HttpMessageNotReadable : {}", ex.getMessage(), ex);
+		final ErrorCode errorCode = ErrorCode.HTTP_MESSAGE_NOT_READABLE;
 		final ErrorResponse errorResponse = ErrorResponse.of(errorCode.getCode(), errorCode.getMessage());
 		final GlobalResponse globalResponse = GlobalResponse.error(errorCode.getCode(), errorResponse);
 		return ResponseEntity.status(errorCode.getStatus()).body(globalResponse);

--- a/src/main/java/taco/klkl/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/taco/klkl/global/error/GlobalExceptionHandler.java
@@ -59,7 +59,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 		WebRequest request
 	) {
 		log.error("HttpRequestMethodNotSupported : {}", ex.getMessage(), ex);
-		final ErrorCode errorCode = ErrorCode.METHOD_NOT_ALLOWED;
+		final ErrorCode errorCode = ErrorCode.METHOD_NOT_SUPPORTED;
 		final ErrorResponse errorResponse = ErrorResponse.of(errorCode.getCode(), errorCode.getMessage());
 		final GlobalResponse globalResponse = GlobalResponse.error(errorCode.getCode(), errorResponse);
 		return ResponseEntity.status(errorCode.getStatus()).body(globalResponse);

--- a/src/main/java/taco/klkl/global/error/exception/ErrorCode.java
+++ b/src/main/java/taco/klkl/global/error/exception/ErrorCode.java
@@ -12,6 +12,7 @@ public enum ErrorCode {
 	METHOD_ARGUMENT_INVALID(HttpStatus.BAD_REQUEST, "C010", "유효하지 않은 method 인자 입니다."),
 	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "C011", "지원하지 않는 HTTP method 입니다."),
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C012", "서버에 문제가 발생했습니다. 관리자에게 문의해주세요."),
+	HTTP_MESSAGE_NOT_READABLE(HttpStatus.BAD_REQUEST, "C013", "잘못된 요청 메시지 형식입니다."),
 
 	// User
 

--- a/src/main/java/taco/klkl/global/error/exception/ErrorCode.java
+++ b/src/main/java/taco/klkl/global/error/exception/ErrorCode.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 public enum ErrorCode {
 	// Common
 	METHOD_ARGUMENT_INVALID(HttpStatus.BAD_REQUEST, "C010", "유효하지 않은 method 인자 입니다."),
-	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "C011", "지원하지 않는 HTTP method 입니다."),
+	METHOD_NOT_SUPPORTED(HttpStatus.METHOD_NOT_ALLOWED, "C011", "지원하지 않는 HTTP method 입니다."),
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C012", "서버에 문제가 발생했습니다. 관리자에게 문의해주세요."),
 	HTTP_MESSAGE_NOT_READABLE(HttpStatus.BAD_REQUEST, "C013", "잘못된 요청 메시지 형식입니다."),
 

--- a/src/main/resources/application-h2.yaml
+++ b/src/main/resources/application-h2.yaml
@@ -7,7 +7,7 @@ spring:
   # Database Setting Info (Database를 H2로 사용하기 위해 H2연결 정보 입력)
   datasource:
     driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:klkldb;NON_KEYWORDS=USER
+    url: jdbc:h2:mem:klkldb;NON_KEYWORDS=USER;MODE=MySQL
 
     username: sa
     password:

--- a/src/test/java/taco/klkl/domain/product/controller/ProductControllerTest.java
+++ b/src/test/java/taco/klkl/domain/product/controller/ProductControllerTest.java
@@ -101,8 +101,8 @@ class ProductControllerTest {
 			2L,
 			3L,
 			4L,
-			"address",
-			1000
+			1000,
+			"address"
 		);
 		when(productService.createProduct(any(ProductCreateRequestDto.class))).thenReturn(productDetailResponseDto);
 

--- a/src/test/java/taco/klkl/domain/product/controller/ProductControllerTest.java
+++ b/src/test/java/taco/klkl/domain/product/controller/ProductControllerTest.java
@@ -161,11 +161,11 @@ class ProductControllerTest {
 		ProductUpdateRequestDto updateRequest = new ProductUpdateRequestDto(
 			"Updated Name",
 			"Updated Description",
+			"Updated Address",
+			2000,
 			2L,
 			3L,
-			4L,
-			"Updated Address",
-			2000
+			4L
 		);
 
 		when(productService.updateProduct(eq(productId), any(ProductUpdateRequestDto.class)))

--- a/src/test/java/taco/klkl/domain/product/controller/ProductControllerTest.java
+++ b/src/test/java/taco/klkl/domain/product/controller/ProductControllerTest.java
@@ -2,6 +2,7 @@ package taco.klkl.domain.product.controller;
 
 import static org.hamcrest.Matchers.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -21,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import taco.klkl.domain.product.domain.Product;
 import taco.klkl.domain.product.dto.request.ProductCreateRequestDto;
+import taco.klkl.domain.product.dto.request.ProductUpdateRequestDto;
 import taco.klkl.domain.product.dto.response.ProductDetailResponseDto;
 import taco.klkl.domain.product.service.ProductService;
 import taco.klkl.domain.user.domain.User;
@@ -38,7 +40,6 @@ class ProductControllerTest {
 	ObjectMapper objectMapper;
 
 	private ProductDetailResponseDto productDetailResponseDto;
-	private ProductCreateRequestDto productCreateRequestDto;
 
 	@BeforeEach
 	public void setUp() {
@@ -64,7 +65,7 @@ class ProductControllerTest {
 		productDetailResponseDto = ProductDetailResponseDto.from(mockProduct);
 
 		// ProductCreateRequestDto 생성
-		productCreateRequestDto = new ProductCreateRequestDto(
+		ProductCreateRequestDto productCreateRequestDto = new ProductCreateRequestDto(
 			"name",
 			"description",
 			2L,
@@ -104,6 +105,15 @@ class ProductControllerTest {
 	@DisplayName("상품 등록 API 테스트")
 	public void testCreateProduct() throws Exception {
 		// given
+		ProductCreateRequestDto productCreateRequestDto = new ProductCreateRequestDto(
+			"name",
+			"description",
+			2L,
+			3L,
+			4L,
+			"address",
+			1000
+		);
 		when(productService.createProduct(any(ProductCreateRequestDto.class))).thenReturn(productDetailResponseDto);
 
 		// when & then
@@ -111,6 +121,44 @@ class ProductControllerTest {
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(productCreateRequestDto)))
 			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.isSuccess", is(true)))
+			.andExpect(jsonPath("$.code", is("C000")))
+			.andExpect(jsonPath("$.data.productId", is(productDetailResponseDto.productId().intValue())))
+			.andExpect(jsonPath("$.data.userId", is(productDetailResponseDto.userId().intValue())))
+			.andExpect(jsonPath("$.data.name", is(productDetailResponseDto.name())))
+			.andExpect(jsonPath("$.data.description", is(productDetailResponseDto.description())))
+			.andExpect(jsonPath("$.data.address", is(productDetailResponseDto.address())))
+			.andExpect(jsonPath("$.data.likeCount", is(productDetailResponseDto.likeCount())))
+			.andExpect(jsonPath("$.data.price", is(productDetailResponseDto.price())))
+			.andExpect(jsonPath("$.data.cityId", is(productDetailResponseDto.cityId().intValue())))
+			.andExpect(jsonPath("$.data.subcategoryId", is(productDetailResponseDto.subcategoryId().intValue())))
+			.andExpect(jsonPath("$.data.currencyId", is(productDetailResponseDto.currencyId().intValue())))
+			.andExpect(jsonPath("$.timestamp", notNullValue()));
+	}
+
+	@Test
+	@DisplayName("상품 정보 부분 업데이트 API 테스트")
+	public void testUpdateProduct() throws Exception {
+		// given
+		Long productId = 1L;
+		ProductUpdateRequestDto updateRequest = new ProductUpdateRequestDto(
+			"Updated Name",
+			"Updated Description",
+			2L,
+			3L,
+			4L,
+			"Updated Address",
+			2000
+		);
+
+		when(productService.updateProduct(eq(productId), any(ProductUpdateRequestDto.class)))
+			.thenReturn(productDetailResponseDto);
+
+		// when & then
+		mockMvc.perform(patch("/v1/products/{id}", productId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(updateRequest)))
+			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.isSuccess", is(true)))
 			.andExpect(jsonPath("$.code", is("C000")))
 			.andExpect(jsonPath("$.data.productId", is(productDetailResponseDto.productId().intValue())))

--- a/src/test/java/taco/klkl/domain/product/controller/ProductControllerTest.java
+++ b/src/test/java/taco/klkl/domain/product/controller/ProductControllerTest.java
@@ -98,11 +98,11 @@ class ProductControllerTest {
 		ProductCreateRequestDto productCreateRequestDto = new ProductCreateRequestDto(
 			"name",
 			"description",
+			"address",
+			1000,
 			2L,
 			3L,
-			4L,
-			1000,
-			"address"
+			4L
 		);
 		when(productService.createProduct(any(ProductCreateRequestDto.class))).thenReturn(productDetailResponseDto);
 
@@ -132,7 +132,7 @@ class ProductControllerTest {
 		// given
 		ProductCreateRequestDto invalidRequestDto = new ProductCreateRequestDto(
 			null,
-			"",
+			null,
 			null,
 			null,
 			null,

--- a/src/test/java/taco/klkl/domain/product/controller/ProductControllerTest.java
+++ b/src/test/java/taco/klkl/domain/product/controller/ProductControllerTest.java
@@ -26,6 +26,7 @@ import taco.klkl.domain.product.dto.request.ProductUpdateRequestDto;
 import taco.klkl.domain.product.dto.response.ProductDetailResponseDto;
 import taco.klkl.domain.product.service.ProductService;
 import taco.klkl.domain.user.domain.User;
+import taco.klkl.global.error.exception.ErrorCode;
 
 @WebMvcTest(ProductController.class)
 class ProductControllerTest {
@@ -63,17 +64,6 @@ class ProductControllerTest {
 
 		// ProductDetailResponseDto 생성
 		productDetailResponseDto = ProductDetailResponseDto.from(mockProduct);
-
-		// ProductCreateRequestDto 생성
-		ProductCreateRequestDto productCreateRequestDto = new ProductCreateRequestDto(
-			"name",
-			"description",
-			2L,
-			3L,
-			4L,
-			"address",
-			1000
-		);
 	}
 
 	@Test
@@ -133,6 +123,33 @@ class ProductControllerTest {
 			.andExpect(jsonPath("$.data.cityId", is(productDetailResponseDto.cityId().intValue())))
 			.andExpect(jsonPath("$.data.subcategoryId", is(productDetailResponseDto.subcategoryId().intValue())))
 			.andExpect(jsonPath("$.data.currencyId", is(productDetailResponseDto.currencyId().intValue())))
+			.andExpect(jsonPath("$.timestamp", notNullValue()));
+	}
+
+	@Test
+	@DisplayName("상품 등록 API 유효성 검사 실패 테스트")
+	public void testCreateProductValidationFailure() throws Exception {
+		// given
+		ProductCreateRequestDto invalidRequestDto = new ProductCreateRequestDto(
+			null,
+			"",
+			null,
+			null,
+			null,
+			null,
+			null
+		);
+
+		// when & then
+		ErrorCode methodArgumentInvalidError = ErrorCode.METHOD_ARGUMENT_INVALID;
+		mockMvc.perform(post("/v1/products")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(invalidRequestDto)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.isSuccess", is(false)))
+			.andExpect(jsonPath("$.code", is(methodArgumentInvalidError.getCode())))
+			.andExpect(jsonPath("$.data.code", is(methodArgumentInvalidError.getCode())))
+			.andExpect(jsonPath("$.data.message", containsString(methodArgumentInvalidError.getMessage())))
 			.andExpect(jsonPath("$.timestamp", notNullValue()));
 	}
 

--- a/src/test/java/taco/klkl/domain/product/domain/ProductTest.java
+++ b/src/test/java/taco/klkl/domain/product/domain/ProductTest.java
@@ -121,11 +121,11 @@ class ProductTest {
 		ProductUpdateRequestDto updateDto = new ProductUpdateRequestDto(
 			"Updated Name",
 			"Updated Description",
-			2L,
-			2L,
-			2L,
 			"Updated Address",
-			200
+			200,
+			2L,
+			2L,
+			2L
 		);
 
 		// when
@@ -159,10 +159,10 @@ class ProductTest {
 			null,
 			"Updated Description",
 			null,
+			200,
+			null,
 			2L,
-			null,
-			null,
-			200
+			null
 		);
 
 		// when

--- a/src/test/java/taco/klkl/domain/product/domain/ProductTest.java
+++ b/src/test/java/taco/klkl/domain/product/domain/ProductTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import taco.klkl.domain.product.dto.request.ProductUpdateRequestDto;
 import taco.klkl.domain.user.domain.User;
 import taco.klkl.global.common.constants.ProductConstants;
 
@@ -76,10 +77,9 @@ class ProductTest {
 	}
 
 	@Test
-	@DisplayName("가격이 null인 상품 생성 시 기본값 0L")
+	@DisplayName("가격이 null인 상품 생성 시 기본값 0")
 	public void testPrePersistWithoutPrice() {
 		// given
-		Long defaultPrice = 0L;
 		String name = "가격없음";
 		String description = "설명";
 		String address = "주소";
@@ -102,5 +102,115 @@ class ProductTest {
 		assertThat(product.getSubcategoryId()).isEqualTo(subcategoryId);
 		assertThat(product.getCurrencyId()).isEqualTo(currencyId);
 		assertThat(product.getLikeCount()).isEqualTo(ProductConstants.DEFAULT_LIKE_COUNT);
+	}
+
+	@Test
+	@DisplayName("상품 정보 업데이트 테스트")
+	public void testUpdate() {
+		// given
+		Product product = Product.of(
+			user,
+			"Original Name",
+			"Original Description",
+			"Original Address",
+			100,
+			1L,
+			1L,
+			1L
+		);
+		ProductUpdateRequestDto updateDto = new ProductUpdateRequestDto(
+			"Updated Name",
+			"Updated Description",
+			2L,
+			2L,
+			2L,
+			"Updated Address",
+			200
+		);
+
+		// when
+		product.update(updateDto);
+
+		// then
+		assertThat(product.getName()).isEqualTo(updateDto.name());
+		assertThat(product.getDescription()).isEqualTo(updateDto.description());
+		assertThat(product.getAddress()).isEqualTo(updateDto.address());
+		assertThat(product.getPrice()).isEqualTo(updateDto.price());
+		assertThat(product.getCityId()).isEqualTo(updateDto.cityId());
+		assertThat(product.getSubcategoryId()).isEqualTo(updateDto.subcategoryId());
+		assertThat(product.getCurrencyId()).isEqualTo(updateDto.currencyId());
+	}
+
+	@Test
+	@DisplayName("상품 정보 부분 업데이트 테스트")
+	public void testPartialUpdate() {
+		// given
+		Product product = Product.of(
+			user,
+			"Original Name",
+			"Original Description",
+			"Original Address",
+			100,
+			1L,
+			1L,
+			1L
+		);
+		ProductUpdateRequestDto updateDto = new ProductUpdateRequestDto(
+			null,
+			"Updated Description",
+			null,
+			2L,
+			null,
+			null,
+			200
+		);
+
+		// when
+		product.update(updateDto);
+
+		// then
+		assertThat(product.getName()).isEqualTo("Original Name");
+		assertThat(product.getDescription()).isEqualTo(updateDto.description());
+		assertThat(product.getAddress()).isEqualTo("Original Address");
+		assertThat(product.getPrice()).isEqualTo(updateDto.price());
+		assertThat(product.getCityId()).isEqualTo(1L);
+		assertThat(product.getSubcategoryId()).isEqualTo(updateDto.subcategoryId());
+		assertThat(product.getCurrencyId()).isEqualTo(1L);
+	}
+
+	@Test
+	@DisplayName("상품 정보 업데이트 시 null 값 무시 테스트")
+	public void testUpdateIgnoreNullValues() {
+		// given
+		Product product = Product.of(
+			user,
+			"Original Name",
+			"Original Description",
+			"Original Address",
+			100,
+			1L,
+			1L,
+			1L);
+		ProductUpdateRequestDto updateDto = new ProductUpdateRequestDto(
+			null,
+			null,
+			null,
+			null,
+			null,
+			null,
+			null
+		);
+
+		// when
+		product.update(updateDto);
+
+		// then
+		assertThat(product.getName()).isEqualTo("Original Name");
+		assertThat(product.getDescription()).isEqualTo("Original Description");
+		assertThat(product.getAddress()).isEqualTo("Original Address");
+		assertThat(product.getPrice()).isEqualTo(100);
+		assertThat(product.getCityId()).isEqualTo(1L);
+		assertThat(product.getSubcategoryId()).isEqualTo(1L);
+		assertThat(product.getCurrencyId()).isEqualTo(1L);
 	}
 }

--- a/src/test/java/taco/klkl/domain/product/dto/request/ProductCreateRequestDtoTest.java
+++ b/src/test/java/taco/klkl/domain/product/dto/request/ProductCreateRequestDtoTest.java
@@ -14,6 +14,7 @@ import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import jakarta.validation.ValidatorFactory;
+import taco.klkl.global.common.constants.ProductValidationMessages;
 
 class ProductCreateRequestDtoTest {
 
@@ -57,7 +58,10 @@ class ProductCreateRequestDtoTest {
 
 		Set<ConstraintViolation<ProductCreateRequestDto>> violations = validator.validate(dto);
 		assertFalse(violations.isEmpty());
-		assertEquals("상품명은 필수 항목입니다.", violations.iterator().next().getMessage());
+
+		boolean foundNotNullMessage = violations.stream()
+			.anyMatch(violation -> violation.getMessage().equals(ProductValidationMessages.NAME_NOT_NULL));
+		assertTrue(foundNotNullMessage, "Expected NAME_NOT_NULL message not found");
 	}
 
 	@Test
@@ -75,7 +79,10 @@ class ProductCreateRequestDtoTest {
 
 		Set<ConstraintViolation<ProductCreateRequestDto>> violations = validator.validate(dto);
 		assertFalse(violations.isEmpty());
-		assertEquals("상품명은 비어있을 수 없습니다.", violations.iterator().next().getMessage());
+
+		boolean foundNotBlankMessage = violations.stream()
+			.anyMatch(violation -> violation.getMessage().equals(ProductValidationMessages.NAME_NOT_BLANK));
+		assertTrue(foundNotBlankMessage, "Expected NAME_NOT_BLANK message not found");
 	}
 
 	@ParameterizedTest
@@ -95,7 +102,7 @@ class ProductCreateRequestDtoTest {
 
 		Set<ConstraintViolation<ProductCreateRequestDto>> violations = validator.validate(dto);
 		assertFalse(violations.isEmpty());
-		assertEquals("상품명은 100자 이하여야 합니다.", violations.iterator().next().getMessage());
+		assertEquals(ProductValidationMessages.NAME_SIZE, violations.iterator().next().getMessage());
 	}
 
 	@Test
@@ -113,7 +120,31 @@ class ProductCreateRequestDtoTest {
 
 		Set<ConstraintViolation<ProductCreateRequestDto>> violations = validator.validate(dto);
 		assertFalse(violations.isEmpty());
-		assertEquals("상품 설명은 필수 항목입니다.", violations.iterator().next().getMessage());
+
+		boolean foundNotNullMessage = violations.stream()
+			.anyMatch(violation -> violation.getMessage().equals(ProductValidationMessages.DESCRIPTION_NOT_NULL));
+		assertTrue(foundNotNullMessage, "Expected DESCRIPTION_NOT_NULL message not found");
+	}
+
+	@Test
+	@DisplayName("상품 설명이 빈 문자열일 때 검증 실패")
+	void emptyProductDescription() {
+		ProductCreateRequestDto dto = new ProductCreateRequestDto(
+			"Valid Product Name",
+			"",
+			"Valid address",
+			100,
+			1L,
+			2L,
+			3L
+		);
+
+		Set<ConstraintViolation<ProductCreateRequestDto>> violations = validator.validate(dto);
+		assertFalse(violations.isEmpty());
+
+		boolean foundNotBlankMessage = violations.stream()
+			.anyMatch(violation -> violation.getMessage().equals(ProductValidationMessages.DESCRIPTION_NOT_BLANK));
+		assertTrue(foundNotBlankMessage, "Expected DESCRIPTION_NOT_BLANK message not found");
 	}
 
 	@ParameterizedTest
@@ -133,7 +164,7 @@ class ProductCreateRequestDtoTest {
 
 		Set<ConstraintViolation<ProductCreateRequestDto>> violations = validator.validate(dto);
 		assertFalse(violations.isEmpty());
-		assertEquals("상품 설명은 2000자 이하여야 합니다.", violations.iterator().next().getMessage());
+		assertEquals(ProductValidationMessages.DESCRIPTION_SIZE, violations.iterator().next().getMessage());
 	}
 
 	@ParameterizedTest
@@ -153,7 +184,7 @@ class ProductCreateRequestDtoTest {
 
 		Set<ConstraintViolation<ProductCreateRequestDto>> violations = validator.validate(dto);
 		assertFalse(violations.isEmpty());
-		assertEquals("주소는 100자 이하여야 합니다.", violations.iterator().next().getMessage());
+		assertEquals(ProductValidationMessages.ADDRESS_SIZE, violations.iterator().next().getMessage());
 	}
 
 	@ParameterizedTest
@@ -172,7 +203,7 @@ class ProductCreateRequestDtoTest {
 
 		Set<ConstraintViolation<ProductCreateRequestDto>> violations = validator.validate(dto);
 		assertFalse(violations.isEmpty());
-		assertEquals("가격은 0 이상이어야 합니다.", violations.iterator().next().getMessage());
+		assertEquals(ProductValidationMessages.PRICE_POSITIVE_OR_ZERO, violations.iterator().next().getMessage());
 	}
 
 	@Test
@@ -190,7 +221,7 @@ class ProductCreateRequestDtoTest {
 
 		Set<ConstraintViolation<ProductCreateRequestDto>> violations = validator.validate(dto);
 		assertFalse(violations.isEmpty());
-		assertEquals("도시 ID는 필수 항목입니다.", violations.iterator().next().getMessage());
+		assertEquals(ProductValidationMessages.CITY_ID_NOT_NULL, violations.iterator().next().getMessage());
 	}
 
 	@Test
@@ -208,7 +239,7 @@ class ProductCreateRequestDtoTest {
 
 		Set<ConstraintViolation<ProductCreateRequestDto>> violations = validator.validate(dto);
 		assertFalse(violations.isEmpty());
-		assertEquals("상품 소분류 ID은 필수 항목입니다.", violations.iterator().next().getMessage());
+		assertEquals(ProductValidationMessages.SUBCATEGORY_ID_NOT_NULL, violations.iterator().next().getMessage());
 	}
 
 	@Test
@@ -226,6 +257,6 @@ class ProductCreateRequestDtoTest {
 
 		Set<ConstraintViolation<ProductCreateRequestDto>> violations = validator.validate(dto);
 		assertFalse(violations.isEmpty());
-		assertEquals("통화 ID는 필수 항목입니다.", violations.iterator().next().getMessage());
+		assertEquals(ProductValidationMessages.CURRENCY_ID_NOT_NULL, violations.iterator().next().getMessage());
 	}
 }

--- a/src/test/java/taco/klkl/domain/product/dto/request/ProductCreateRequestDtoTest.java
+++ b/src/test/java/taco/klkl/domain/product/dto/request/ProductCreateRequestDtoTest.java
@@ -23,19 +23,61 @@ class ProductCreateRequestDtoTest {
 	}
 
 	@Test
-	@DisplayName("모든 필수 필드가 존재할 때 유효성 검사 성공")
-	void testProductCreateRequestDtoWithAllRequiredFields() {
+	@DisplayName("모든 필수 필드가 존재하고 가격이 양수일 때 유효성 검사 성공")
+	void testProductCreateRequestDtoWithAllRequiredFieldsAndPositivePrice() {
 		// given
-		String name = "맛있는 곤약젤리";
-		String description = "탱글탱글 맛있는 곤약젤리";
-		Long cityId = 1L;
-		Long subcategoryId = 2L;
-		Long currencyId = 3L;
-		String address = "신사이바시 메가돈키호테";
-		Integer price = 100;
+		ProductCreateRequestDto dto = new ProductCreateRequestDto(
+			"맛있는 곤약젤리",
+			"탱글탱글 맛있는 곤약젤리",
+			1L,
+			2L,
+			3L,
+			100,
+			"신사이바시 메가돈키호테"
+		);
 
-		ProductCreateRequestDto dto = new ProductCreateRequestDto(name, description, cityId, subcategoryId, currencyId,
-			address, price);
+		// when
+		Set<ConstraintViolation<ProductCreateRequestDto>> violations = validator.validate(dto);
+
+		// then
+		assertTrue(violations.isEmpty());
+	}
+
+	@Test
+	@DisplayName("가격이 음수일 때 유효성 검사 실패")
+	void testProductCreateRequestDtoWithNegativePrice() {
+		// given
+		ProductCreateRequestDto dto = new ProductCreateRequestDto(
+			"맛있는 곤약젤리",
+			"탱글탱글 맛있는 곤약젤리",
+			1L,
+			2L,
+			3L,
+			-100,
+			"신사이바시 메가돈키호테"
+		);
+
+		// when
+		Set<ConstraintViolation<ProductCreateRequestDto>> violations = validator.validate(dto);
+
+		// then
+		assertFalse(violations.isEmpty());
+		assertEquals("가격은 0 이상이어야 합니다.", violations.iterator().next().getMessage());
+	}
+
+	@Test
+	@DisplayName("가격이 0일 때 유효성 검사 성공")
+	void testProductCreateRequestDtoWithZeroPrice() {
+		// given
+		ProductCreateRequestDto dto = new ProductCreateRequestDto(
+			"맛있는 곤약젤리",
+			"탱글탱글 맛있는 곤약젤리",
+			1L,
+			2L,
+			3L,
+			0,
+			"신사이바시 메가돈키호테"
+		);
 
 		// when
 		Set<ConstraintViolation<ProductCreateRequestDto>> violations = validator.validate(dto);
@@ -54,8 +96,8 @@ class ProductCreateRequestDtoTest {
 			1L,
 			2L,
 			3L,
-			"신사이바시 메가돈키호테",
-			100
+			100,
+			"신사이바시 메가돈키호테"
 		);
 
 		// when
@@ -76,8 +118,8 @@ class ProductCreateRequestDtoTest {
 			1L,
 			2L,
 			3L,
-			"신사이바시 메가돈키호테",
-			100
+			100,
+			"신사이바시 메가돈키호테"
 		);
 
 		// when
@@ -98,8 +140,8 @@ class ProductCreateRequestDtoTest {
 			null,
 			2L,
 			3L,
-			"신사이바시 메가돈키호테",
-			100
+			100,
+			"신사이바시 메가돈키호테"
 		);
 
 		// when
@@ -120,8 +162,8 @@ class ProductCreateRequestDtoTest {
 			1L,
 			null,
 			3L,
-			"신사이바시 메가돈키호테",
-			100
+			100,
+			"신사이바시 메가돈키호테"
 		);
 
 		// when
@@ -142,8 +184,8 @@ class ProductCreateRequestDtoTest {
 			1L,
 			2L,
 			null,
-			"신사이바시 메가돈키호테",
-			100
+			100,
+			"신사이바시 메가돈키호테"
 		);
 
 		// when
@@ -155,8 +197,8 @@ class ProductCreateRequestDtoTest {
 	}
 
 	@Test
-	@DisplayName("여러 필수 필드가 null일 때 유효성 검사 실패")
-	void testProductCreateRequestDtoWithMultipleNullFields() {
+	@DisplayName("여러 필수 필드가 null이고 가격이 음수일 때 유효성 검사 실패")
+	void testProductCreateRequestDtoWithMultipleNullFieldsAndNegativePrice() {
 		// given
 		ProductCreateRequestDto dto = new ProductCreateRequestDto(
 			null,
@@ -164,19 +206,20 @@ class ProductCreateRequestDtoTest {
 			null,
 			null,
 			null,
-			"address",
-			100
+			-100,
+			"address"
 		);
 
 		// when
 		Set<ConstraintViolation<ProductCreateRequestDto>> violations = validator.validate(dto);
 
 		// then
-		assertEquals(5, violations.size());
+		assertEquals(6, violations.size());
 		assertTrue(violations.stream().anyMatch(v -> v.getMessage().equals("상품명은 필수 항목입니다.")));
 		assertTrue(violations.stream().anyMatch(v -> v.getMessage().equals("상품 설명은 필수 항목입니다.")));
 		assertTrue(violations.stream().anyMatch(v -> v.getMessage().equals("도시 ID는 필수 항목입니다.")));
 		assertTrue(violations.stream().anyMatch(v -> v.getMessage().equals("상품 소분류 ID은 필수 항목입니다.")));
 		assertTrue(violations.stream().anyMatch(v -> v.getMessage().equals("통화 ID는 필수 항목입니다.")));
+		assertTrue(violations.stream().anyMatch(v -> v.getMessage().equals("가격은 0 이상이어야 합니다.")));
 	}
 }

--- a/src/test/java/taco/klkl/domain/product/dto/request/ProductCreateRequestDtoTest.java
+++ b/src/test/java/taco/klkl/domain/product/dto/request/ProductCreateRequestDtoTest.java
@@ -7,6 +7,8 @@ import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
@@ -14,6 +16,7 @@ import jakarta.validation.Validator;
 import jakarta.validation.ValidatorFactory;
 
 class ProductCreateRequestDtoTest {
+
 	private Validator validator;
 
 	@BeforeEach
@@ -23,203 +26,206 @@ class ProductCreateRequestDtoTest {
 	}
 
 	@Test
-	@DisplayName("모든 필수 필드가 존재하고 가격이 양수일 때 유효성 검사 성공")
-	void testProductCreateRequestDtoWithAllRequiredFieldsAndPositivePrice() {
-		// given
+	@DisplayName("유효한 ProductCreateRequestDto 생성 시 검증 통과")
+	void validProductCreateRequestDto() {
 		ProductCreateRequestDto dto = new ProductCreateRequestDto(
-			"맛있는 곤약젤리",
-			"탱글탱글 맛있는 곤약젤리",
-			1L,
-			2L,
-			3L,
+			"Valid Product Name",
+			"Valid product description",
+			"Valid address",
 			100,
-			"신사이바시 메가돈키호테"
+			1L,
+			2L,
+			3L
 		);
 
-		// when
 		Set<ConstraintViolation<ProductCreateRequestDto>> violations = validator.validate(dto);
-
-		// then
 		assertTrue(violations.isEmpty());
 	}
 
 	@Test
-	@DisplayName("가격이 음수일 때 유효성 검사 실패")
-	void testProductCreateRequestDtoWithNegativePrice() {
-		// given
-		ProductCreateRequestDto dto = new ProductCreateRequestDto(
-			"맛있는 곤약젤리",
-			"탱글탱글 맛있는 곤약젤리",
-			1L,
-			2L,
-			3L,
-			-100,
-			"신사이바시 메가돈키호테"
-		);
-
-		// when
-		Set<ConstraintViolation<ProductCreateRequestDto>> violations = validator.validate(dto);
-
-		// then
-		assertFalse(violations.isEmpty());
-		assertEquals("가격은 0 이상이어야 합니다.", violations.iterator().next().getMessage());
-	}
-
-	@Test
-	@DisplayName("가격이 0일 때 유효성 검사 성공")
-	void testProductCreateRequestDtoWithZeroPrice() {
-		// given
-		ProductCreateRequestDto dto = new ProductCreateRequestDto(
-			"맛있는 곤약젤리",
-			"탱글탱글 맛있는 곤약젤리",
-			1L,
-			2L,
-			3L,
-			0,
-			"신사이바시 메가돈키호테"
-		);
-
-		// when
-		Set<ConstraintViolation<ProductCreateRequestDto>> violations = validator.validate(dto);
-
-		// then
-		assertTrue(violations.isEmpty());
-	}
-
-	@Test
-	@DisplayName("상품명이 null일 때 유효성 검사 실패")
-	void testProductCreateRequestDtoWithNullName() {
-		// given
+	@DisplayName("상품명이 null일 때 검증 실패")
+	void nullProductName() {
 		ProductCreateRequestDto dto = new ProductCreateRequestDto(
 			null,
-			"탱글탱글 맛있는 곤약젤리",
+			"Valid product description",
+			"Valid address",
+			100,
 			1L,
 			2L,
-			3L,
-			100,
-			"신사이바시 메가돈키호테"
+			3L
 		);
 
-		// when
 		Set<ConstraintViolation<ProductCreateRequestDto>> violations = validator.validate(dto);
-
-		// then
 		assertFalse(violations.isEmpty());
 		assertEquals("상품명은 필수 항목입니다.", violations.iterator().next().getMessage());
 	}
 
 	@Test
-	@DisplayName("상품 설명이 null일 때 유효성 검사 실패")
-	void testProductCreateRequestDtoWithNullDescription() {
-		// given
+	@DisplayName("상품명이 빈 문자열일 때 검증 실패")
+	void emptyProductName() {
 		ProductCreateRequestDto dto = new ProductCreateRequestDto(
-			"맛있는 곤약젤리",
-			null,
+			"",
+			"Valid product description",
+			"Valid address",
+			100,
 			1L,
 			2L,
-			3L,
-			100,
-			"신사이바시 메가돈키호테"
+			3L
 		);
 
-		// when
 		Set<ConstraintViolation<ProductCreateRequestDto>> violations = validator.validate(dto);
+		assertFalse(violations.isEmpty());
+		assertEquals("상품명은 비어있을 수 없습니다.", violations.iterator().next().getMessage());
+	}
 
-		// then
+	@ParameterizedTest
+	@ValueSource(ints = {101, 200, 1000})
+	@DisplayName("상품명이 최대 길이를 초과할 때 검증 실패")
+	void productNameExceedsMaxLength(int nameLength) {
+		String longName = "a".repeat(nameLength);
+		ProductCreateRequestDto dto = new ProductCreateRequestDto(
+			longName,
+			"Valid product description",
+			"Valid address",
+			100,
+			1L,
+			2L,
+			3L
+		);
+
+		Set<ConstraintViolation<ProductCreateRequestDto>> violations = validator.validate(dto);
+		assertFalse(violations.isEmpty());
+		assertEquals("상품명은 100자 이하여야 합니다.", violations.iterator().next().getMessage());
+	}
+
+	@Test
+	@DisplayName("상품 설명이 null일 때 검증 실패")
+	void nullProductDescription() {
+		ProductCreateRequestDto dto = new ProductCreateRequestDto(
+			"Valid Product Name",
+			null,
+			"Valid address",
+			100,
+			1L,
+			2L,
+			3L
+		);
+
+		Set<ConstraintViolation<ProductCreateRequestDto>> violations = validator.validate(dto);
 		assertFalse(violations.isEmpty());
 		assertEquals("상품 설명은 필수 항목입니다.", violations.iterator().next().getMessage());
 	}
 
-	@Test
-	@DisplayName("도시 ID가 null일 때 유효성 검사 실패")
-	void testProductCreateRequestDtoWithNullCityId() {
-		// given
+	@ParameterizedTest
+	@ValueSource(ints = {2001, 3000, 5000})
+	@DisplayName("상품 설명이 최대 길이를 초과할 때 검증 실패")
+	void productDescriptionExceedsMaxLength(int descriptionLength) {
+		String longDescription = "a".repeat(descriptionLength);
 		ProductCreateRequestDto dto = new ProductCreateRequestDto(
-			"맛있는 곤약젤리",
-			"탱글탱글 맛있는 곤약젤리",
-			null,
-			2L,
-			3L,
+			"Valid Product Name",
+			longDescription,
+			"Valid address",
 			100,
-			"신사이바시 메가돈키호테"
+			1L,
+			2L,
+			3L
 		);
 
-		// when
 		Set<ConstraintViolation<ProductCreateRequestDto>> violations = validator.validate(dto);
+		assertFalse(violations.isEmpty());
+		assertEquals("상품 설명은 2000자 이하여야 합니다.", violations.iterator().next().getMessage());
+	}
 
-		// then
+	@ParameterizedTest
+	@ValueSource(ints = {101, 200, 500})
+	@DisplayName("주소가 최대 길이를 초과할 때 검증 실패")
+	void addressExceedsMaxLength(int addressLength) {
+		String longAddress = "a".repeat(addressLength);
+		ProductCreateRequestDto dto = new ProductCreateRequestDto(
+			"Valid Product Name",
+			"Valid product description",
+			longAddress,
+			100,
+			1L,
+			2L,
+			3L
+		);
+
+		Set<ConstraintViolation<ProductCreateRequestDto>> violations = validator.validate(dto);
+		assertFalse(violations.isEmpty());
+		assertEquals("주소는 100자 이하여야 합니다.", violations.iterator().next().getMessage());
+	}
+
+	@ParameterizedTest
+	@ValueSource(ints = {-1, -100, -1000})
+	@DisplayName("가격이 음수일 때 검증 실패")
+	void negativePrice(int price) {
+		ProductCreateRequestDto dto = new ProductCreateRequestDto(
+			"Valid Product Name",
+			"Valid product description",
+			"Valid address",
+			price,
+			1L,
+			2L,
+			3L
+		);
+
+		Set<ConstraintViolation<ProductCreateRequestDto>> violations = validator.validate(dto);
+		assertFalse(violations.isEmpty());
+		assertEquals("가격은 0 이상이어야 합니다.", violations.iterator().next().getMessage());
+	}
+
+	@Test
+	@DisplayName("도시 ID가 null일 때 검증 실패")
+	void nullCityId() {
+		ProductCreateRequestDto dto = new ProductCreateRequestDto(
+			"Valid Product Name",
+			"Valid product description",
+			"Valid address",
+			100,
+			null,
+			2L,
+			3L
+		);
+
+		Set<ConstraintViolation<ProductCreateRequestDto>> violations = validator.validate(dto);
 		assertFalse(violations.isEmpty());
 		assertEquals("도시 ID는 필수 항목입니다.", violations.iterator().next().getMessage());
 	}
 
 	@Test
-	@DisplayName("상품 소분류 ID가 null일 때 유효성 검사 실패")
-	void testProductCreateRequestDtoWithNullSubcategoryId() {
-		// given
+	@DisplayName("상품 소분류 ID가 null일 때 검증 실패")
+	void nullSubcategoryId() {
 		ProductCreateRequestDto dto = new ProductCreateRequestDto(
-			"맛있는 곤약젤리",
-			"탱글탱글 맛있는 곤약젤리",
+			"Valid Product Name",
+			"Valid product description",
+			"Valid address",
+			100,
 			1L,
 			null,
-			3L,
-			100,
-			"신사이바시 메가돈키호테"
+			3L
 		);
 
-		// when
 		Set<ConstraintViolation<ProductCreateRequestDto>> violations = validator.validate(dto);
-
-		// then
 		assertFalse(violations.isEmpty());
 		assertEquals("상품 소분류 ID은 필수 항목입니다.", violations.iterator().next().getMessage());
 	}
 
 	@Test
-	@DisplayName("통화 ID가 null일 때 유효성 검사 실패")
-	void testProductCreateRequestDtoWithNullCurrencyId() {
-		// given
+	@DisplayName("통화 ID가 null일 때 검증 실패")
+	void nullCurrencyId() {
 		ProductCreateRequestDto dto = new ProductCreateRequestDto(
-			"맛있는 곤약젤리",
-			"탱글탱글 맛있는 곤약젤리",
+			"Valid Product Name",
+			"Valid product description",
+			"Valid address",
+			100,
 			1L,
 			2L,
-			null,
-			100,
-			"신사이바시 메가돈키호테"
+			null
 		);
 
-		// when
 		Set<ConstraintViolation<ProductCreateRequestDto>> violations = validator.validate(dto);
-
-		// then
 		assertFalse(violations.isEmpty());
 		assertEquals("통화 ID는 필수 항목입니다.", violations.iterator().next().getMessage());
-	}
-
-	@Test
-	@DisplayName("여러 필수 필드가 null이고 가격이 음수일 때 유효성 검사 실패")
-	void testProductCreateRequestDtoWithMultipleNullFieldsAndNegativePrice() {
-		// given
-		ProductCreateRequestDto dto = new ProductCreateRequestDto(
-			null,
-			null,
-			null,
-			null,
-			null,
-			-100,
-			"address"
-		);
-
-		// when
-		Set<ConstraintViolation<ProductCreateRequestDto>> violations = validator.validate(dto);
-
-		// then
-		assertEquals(6, violations.size());
-		assertTrue(violations.stream().anyMatch(v -> v.getMessage().equals("상품명은 필수 항목입니다.")));
-		assertTrue(violations.stream().anyMatch(v -> v.getMessage().equals("상품 설명은 필수 항목입니다.")));
-		assertTrue(violations.stream().anyMatch(v -> v.getMessage().equals("도시 ID는 필수 항목입니다.")));
-		assertTrue(violations.stream().anyMatch(v -> v.getMessage().equals("상품 소분류 ID은 필수 항목입니다.")));
-		assertTrue(violations.stream().anyMatch(v -> v.getMessage().equals("통화 ID는 필수 항목입니다.")));
-		assertTrue(violations.stream().anyMatch(v -> v.getMessage().equals("가격은 0 이상이어야 합니다.")));
 	}
 }

--- a/src/test/java/taco/klkl/domain/product/dto/request/ProductUpdateRequestDtoTest.java
+++ b/src/test/java/taco/klkl/domain/product/dto/request/ProductUpdateRequestDtoTest.java
@@ -7,13 +7,17 @@ import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import jakarta.validation.ValidatorFactory;
+import taco.klkl.global.common.constants.ProductValidationMessages;
 
 class ProductUpdateRequestDtoTest {
+
 	private Validator validator;
 
 	@BeforeEach
@@ -23,65 +27,119 @@ class ProductUpdateRequestDtoTest {
 	}
 
 	@Test
-	@DisplayName("모든 필드가 유효한 값일 때 유효성 검사 성공")
-	void testProductUpdateRequestDtoWithAllValidFields() {
-		// given
+	@DisplayName("유효한 ProductUpdateRequestDto 생성 시 검증 통과")
+	void validProductUpdateRequestDto() {
 		ProductUpdateRequestDto dto = new ProductUpdateRequestDto(
-			"맛있는 곤약젤리",
-			"탱글탱글 맛있는 곤약젤리",
+			"Valid Product Name",
+			"Valid product description",
+			"Valid address",
+			100,
 			1L,
 			2L,
-			3L,
-			"신사이바시 메가돈키호테",
-			100
+			3L
 		);
 
-		// when
 		Set<ConstraintViolation<ProductUpdateRequestDto>> violations = validator.validate(dto);
-
-		// then
 		assertTrue(violations.isEmpty());
 	}
 
-	@Test
-	@DisplayName("모든 필드가 null일 때 유효성 검사 성공")
-	void testProductUpdateRequestDtoWithAllNullFields() {
-		// given
+	@ParameterizedTest
+	@ValueSource(ints = {101, 200, 1000})
+	@DisplayName("상품명이 최대 길이를 초과할 때 검증 실패")
+	void productNameExceedsMaxLength(int nameLength) {
+		String longName = "a".repeat(nameLength);
 		ProductUpdateRequestDto dto = new ProductUpdateRequestDto(
-			null,
-			null,
-			null,
-			null,
-			null,
-			null,
-			null
-		);
-
-		// when
-		Set<ConstraintViolation<ProductUpdateRequestDto>> violations = validator.validate(dto);
-
-		// then
-		assertTrue(violations.isEmpty());
-	}
-
-	@Test
-	@DisplayName("일부 필드가 null일 때 유효성 검사 성공")
-	void testProductUpdateRequestDtoWithSomeNullFields() {
-		// given
-		ProductUpdateRequestDto dto = new ProductUpdateRequestDto(
-			"맛있는 곤약젤리",
-			null,
+			longName,
+			"Valid product description",
+			"Valid address",
+			100,
 			1L,
+			2L,
+			3L
+		);
+
+		Set<ConstraintViolation<ProductUpdateRequestDto>> violations = validator.validate(dto);
+		assertFalse(violations.isEmpty());
+		assertTrue(violations.stream()
+			.anyMatch(violation -> violation.getMessage().equals(ProductValidationMessages.NAME_SIZE)));
+	}
+
+	@ParameterizedTest
+	@ValueSource(ints = {2001, 3000, 5000})
+	@DisplayName("상품 설명이 최대 길이를 초과할 때 검증 실패")
+	void productDescriptionExceedsMaxLength(int descriptionLength) {
+		String longDescription = "a".repeat(descriptionLength);
+		ProductUpdateRequestDto dto = new ProductUpdateRequestDto(
+			"Valid Product Name",
+			longDescription,
+			"Valid address",
+			100,
+			1L,
+			2L,
+			3L
+		);
+
+		Set<ConstraintViolation<ProductUpdateRequestDto>> violations = validator.validate(dto);
+		assertFalse(violations.isEmpty());
+		assertTrue(violations.stream()
+			.anyMatch(violation -> violation.getMessage().equals(ProductValidationMessages.DESCRIPTION_SIZE)));
+	}
+
+	@ParameterizedTest
+	@ValueSource(ints = {101, 200, 500})
+	@DisplayName("주소가 최대 길이를 초과할 때 검증 실패")
+	void addressExceedsMaxLength(int addressLength) {
+		String longAddress = "a".repeat(addressLength);
+		ProductUpdateRequestDto dto = new ProductUpdateRequestDto(
+			"Valid Product Name",
+			"Valid product description",
+			longAddress,
+			100,
+			1L,
+			2L,
+			3L
+		);
+
+		Set<ConstraintViolation<ProductUpdateRequestDto>> violations = validator.validate(dto);
+		assertFalse(violations.isEmpty());
+		assertTrue(violations.stream()
+			.anyMatch(violation -> violation.getMessage().equals(ProductValidationMessages.ADDRESS_SIZE)));
+	}
+
+	@ParameterizedTest
+	@ValueSource(ints = {-1, -100, -1000})
+	@DisplayName("가격이 음수일 때 검증 실패")
+	void negativePrice(int price) {
+		ProductUpdateRequestDto dto = new ProductUpdateRequestDto(
+			"Valid Product Name",
+			"Valid product description",
+			"Valid address",
+			price,
+			1L,
+			2L,
+			3L
+		);
+
+		Set<ConstraintViolation<ProductUpdateRequestDto>> violations = validator.validate(dto);
+		assertFalse(violations.isEmpty());
+		assertTrue(violations.stream()
+			.anyMatch(violation -> violation.getMessage().equals(ProductValidationMessages.PRICE_POSITIVE_OR_ZERO)));
+	}
+
+	@Test
+	@DisplayName("모든 필드가 null이어도 검증 통과 (부분 업데이트 허용)")
+	void allFieldsNullShouldPass() {
+		ProductUpdateRequestDto dto = new ProductUpdateRequestDto(
 			null,
-			3L,
-			"신사이바시 메가돈키호테",
+			null,
+			null,
+			null,
+			null,
+			null,
 			null
 		);
 
-		// when
 		Set<ConstraintViolation<ProductUpdateRequestDto>> violations = validator.validate(dto);
-
-		// then
 		assertTrue(violations.isEmpty());
 	}
 }

--- a/src/test/java/taco/klkl/domain/product/integration/ProductIntegrationTest.java
+++ b/src/test/java/taco/klkl/domain/product/integration/ProductIntegrationTest.java
@@ -42,11 +42,11 @@ public class ProductIntegrationTest {
 		ProductCreateRequestDto createDto = new ProductCreateRequestDto(
 			"name",
 			"description",
+			"address",
+			1000,
 			2L,
 			3L,
-			4L,
-			1000,
-			"address"
+			4L
 		);
 		ProductDetailResponseDto productDto = productService.createProduct(createDto);
 
@@ -75,11 +75,11 @@ public class ProductIntegrationTest {
 		ProductCreateRequestDto createDto = new ProductCreateRequestDto(
 			"name",
 			"description",
+			"address",
+			1000,
 			2L,
 			3L,
-			4L,
-			1000,
-			"address"
+			4L
 		);
 
 		// when & then

--- a/src/test/java/taco/klkl/domain/product/integration/ProductIntegrationTest.java
+++ b/src/test/java/taco/klkl/domain/product/integration/ProductIntegrationTest.java
@@ -45,8 +45,8 @@ public class ProductIntegrationTest {
 			2L,
 			3L,
 			4L,
-			"address",
-			1000
+			1000,
+			"address"
 		);
 		ProductDetailResponseDto productDto = productService.createProduct(createDto);
 
@@ -78,8 +78,8 @@ public class ProductIntegrationTest {
 			2L,
 			3L,
 			4L,
-			"address",
-			1000
+			1000,
+			"address"
 		);
 
 		// when & then

--- a/src/test/java/taco/klkl/domain/product/service/ProductServiceTest.java
+++ b/src/test/java/taco/klkl/domain/product/service/ProductServiceTest.java
@@ -197,7 +197,6 @@ class ProductServiceTest {
 		assertThat(responseDto.currencyId()).isEqualTo(updateDto.currencyId());
 
 		verify(productRepository).findById(productId);
-		verify(productRepository).save(any(Product.class));
 	}
 
 	@Test

--- a/src/test/java/taco/klkl/domain/product/service/ProductServiceTest.java
+++ b/src/test/java/taco/klkl/domain/product/service/ProductServiceTest.java
@@ -111,8 +111,8 @@ class ProductServiceTest {
 			2L,
 			3L,
 			4L,
-			"신사이바시 메가돈키호테",
-			100
+			100,
+			"신사이바시 메가돈키호테"
 		);
 
 		String name = productDto.name();

--- a/src/test/java/taco/klkl/domain/product/service/ProductServiceTest.java
+++ b/src/test/java/taco/klkl/domain/product/service/ProductServiceTest.java
@@ -16,6 +16,7 @@ import org.mockito.MockitoAnnotations;
 import taco.klkl.domain.product.dao.ProductRepository;
 import taco.klkl.domain.product.domain.Product;
 import taco.klkl.domain.product.dto.request.ProductCreateRequestDto;
+import taco.klkl.domain.product.dto.request.ProductUpdateRequestDto;
 import taco.klkl.domain.product.dto.response.ProductDetailResponseDto;
 import taco.klkl.domain.product.exception.ProductNotFoundException;
 import taco.klkl.domain.user.domain.User;
@@ -151,5 +152,79 @@ class ProductServiceTest {
 		assertThat(responseDto.currencyId()).isEqualTo(currencyId);
 
 		verify(productRepository).save(any(Product.class));
+	}
+
+	@Test
+	@DisplayName("상품 업데이트 성공 테스트")
+	void testUpdateProduct_Success() {
+		// given
+		Long productId = 1L;
+		Product existingProduct = Product.of(
+			user,
+			"Original Name",
+			"Original Description",
+			"Original Address",
+			100,
+			1L,
+			1L,
+			1L
+		);
+
+		ProductUpdateRequestDto updateDto = new ProductUpdateRequestDto(
+			"Updated Name",
+			"Updated Description",
+			2L,
+			2L,
+			2L,
+			"Updated Address",
+			200
+		);
+
+		when(productRepository.findById(productId)).thenReturn(Optional.of(existingProduct));
+		when(productRepository.save(any(Product.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+		// when
+		ProductDetailResponseDto responseDto = productService.updateProduct(productId, updateDto);
+
+		// then
+		assertThat(responseDto).isNotNull();
+		assertThat(responseDto.name()).isEqualTo(updateDto.name());
+		assertThat(responseDto.description()).isEqualTo(updateDto.description());
+		assertThat(responseDto.address()).isEqualTo(updateDto.address());
+		assertThat(responseDto.price()).isEqualTo(updateDto.price());
+		assertThat(responseDto.cityId()).isEqualTo(updateDto.cityId());
+		assertThat(responseDto.subcategoryId()).isEqualTo(updateDto.subcategoryId());
+		assertThat(responseDto.currencyId()).isEqualTo(updateDto.currencyId());
+
+		verify(productRepository).findById(productId);
+		verify(productRepository).save(any(Product.class));
+	}
+
+	@Test
+	@DisplayName("상품 업데이트 실패 테스트 - 상품 없음")
+	void testUpdateProduct_NotFound() {
+		// given
+		Long productId = 1L;
+		ProductUpdateRequestDto updateDto = new ProductUpdateRequestDto(
+			"Updated Name",
+			"Updated Description",
+			2L,
+			2L,
+			2L,
+			"Updated Address",
+			200
+		);
+
+		when(productRepository.findById(productId)).thenReturn(Optional.empty());
+
+		// when & then
+		ProductNotFoundException exception = assertThrows(ProductNotFoundException.class, () -> {
+			productService.updateProduct(productId, updateDto);
+		});
+
+		// 예외가 발생했는지 확인
+		assertThat(exception).isNotNull();
+		verify(productRepository).findById(productId);
+		verify(productRepository, never()).save(any(Product.class));
 	}
 }

--- a/src/test/java/taco/klkl/domain/product/service/ProductServiceTest.java
+++ b/src/test/java/taco/klkl/domain/product/service/ProductServiceTest.java
@@ -108,11 +108,11 @@ class ProductServiceTest {
 		ProductCreateRequestDto productDto = new ProductCreateRequestDto(
 			"맛있는 곤약젤리",
 			"탱글탱글 맛있는 곤약젤리",
+			"신사이바시 메가돈키호테",
+			100,
 			2L,
 			3L,
-			4L,
-			100,
-			"신사이바시 메가돈키호테"
+			4L
 		);
 
 		String name = productDto.name();

--- a/src/test/java/taco/klkl/domain/product/service/ProductServiceTest.java
+++ b/src/test/java/taco/klkl/domain/product/service/ProductServiceTest.java
@@ -173,11 +173,11 @@ class ProductServiceTest {
 		ProductUpdateRequestDto updateDto = new ProductUpdateRequestDto(
 			"Updated Name",
 			"Updated Description",
-			2L,
-			2L,
-			2L,
 			"Updated Address",
-			200
+			200,
+			2L,
+			2L,
+			2L
 		);
 
 		when(productRepository.findById(productId)).thenReturn(Optional.of(existingProduct));
@@ -208,11 +208,11 @@ class ProductServiceTest {
 		ProductUpdateRequestDto updateDto = new ProductUpdateRequestDto(
 			"Updated Name",
 			"Updated Description",
-			2L,
-			2L,
-			2L,
 			"Updated Address",
-			200
+			200,
+			2L,
+			2L,
+			2L
 		);
 
 		when(productRepository.findById(productId)).thenReturn(Optional.empty());

--- a/src/test/java/taco/klkl/global/error/GlobalExceptionHandlerTest.java
+++ b/src/test/java/taco/klkl/global/error/GlobalExceptionHandlerTest.java
@@ -89,8 +89,8 @@ class GlobalExceptionHandlerTest {
 		GlobalResponse globalResponse = (GlobalResponse)(response.getBody());
 		assertInstanceOf(ErrorResponse.class, globalResponse.data());
 		ErrorResponse errorResponse = (ErrorResponse)(globalResponse.data());
-		assertEquals("C011", errorResponse.code());
-		assertEquals("지원하지 않는 HTTP method 입니다.", errorResponse.message());
+		assertEquals(ErrorCode.METHOD_NOT_SUPPORTED.getCode(), errorResponse.code());
+		assertEquals(ErrorCode.METHOD_NOT_SUPPORTED.getMessage(), errorResponse.message());
 	}
 
 	@Test
@@ -113,8 +113,8 @@ class GlobalExceptionHandlerTest {
 		GlobalResponse globalResponse = (GlobalResponse)(response.getBody());
 		assertInstanceOf(ErrorResponse.class, globalResponse.data());
 		ErrorResponse errorResponse = (ErrorResponse)(globalResponse.data());
-		assertEquals("C012", errorResponse.code());
-		assertEquals("서버에 문제가 발생했습니다. 관리자에게 문의해주세요.", errorResponse.message());
+		assertEquals(ErrorCode.INTERNAL_SERVER_ERROR.getCode(), errorResponse.code());
+		assertEquals(ErrorCode.INTERNAL_SERVER_ERROR.getMessage(), errorResponse.message());
 	}
 
 	@Test
@@ -159,8 +159,8 @@ class GlobalExceptionHandlerTest {
 		GlobalResponse globalResponse = (GlobalResponse)(response.getBody());
 		assertInstanceOf(ErrorResponse.class, globalResponse.data());
 		ErrorResponse errorResponse = (ErrorResponse)(globalResponse.data());
-		assertEquals("C999", errorResponse.code());
-		assertEquals("샘플 에러입니다.", errorResponse.message());
+		assertEquals(ErrorCode.SAMPLE_ERROR.getCode(), errorResponse.code());
+		assertEquals(ErrorCode.SAMPLE_ERROR.getMessage(), errorResponse.message());
 	}
 
 	@Test
@@ -178,7 +178,7 @@ class GlobalExceptionHandlerTest {
 		assertNotNull(response.getBody());
 		GlobalResponse globalResponse = (GlobalResponse)(response.getBody());
 		ErrorResponse errorResponse = (ErrorResponse)(globalResponse.data());
-		assertEquals("C012", errorResponse.code());
-		assertEquals("서버에 문제가 발생했습니다. 관리자에게 문의해주세요.", errorResponse.message());
+		assertEquals(ErrorCode.INTERNAL_SERVER_ERROR.getCode(), errorResponse.code());
+		assertEquals(ErrorCode.INTERNAL_SERVER_ERROR.getMessage(), errorResponse.message());
 	}
 }

--- a/src/test/java/taco/klkl/global/error/GlobalExceptionHandlerTest.java
+++ b/src/test/java/taco/klkl/global/error/GlobalExceptionHandlerTest.java
@@ -3,12 +3,16 @@ package taco.klkl.global.error;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.util.List;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.context.request.WebRequest;
@@ -30,7 +34,21 @@ class GlobalExceptionHandlerTest {
 	@DisplayName("MethodArgumentNotValidException이 발생한 경우")
 	void methodArgumentNotValidOccurred() {
 		// given
+		BindingResult bindingResult = mock(BindingResult.class);
 		MethodArgumentNotValidException exception = mock(MethodArgumentNotValidException.class);
+
+		// Mock the field errors
+		List<FieldError> fieldErrors = List.of(
+			new FieldError("productCreateRequestDto", "name", "상품명은 필수 항목입니다."),
+			new FieldError("productCreateRequestDto", "description", "상품 설명은 필수 항목입니다."),
+			new FieldError("productCreateRequestDto", "cityId", "도시 ID는 필수 항목입니다."),
+			new FieldError("productCreateRequestDto", "subcategoryId", "상품 소분류 ID는 필수 항목입니다."),
+			new FieldError("productCreateRequestDto", "currencyId", "통화 ID는 필수 항목입니다.")
+		);
+
+		when(bindingResult.getFieldErrors()).thenReturn(fieldErrors);
+		when(exception.getBindingResult()).thenReturn(bindingResult);
+
 		HttpHeaders headers = new HttpHeaders();
 		HttpStatus status = HttpStatus.BAD_REQUEST;
 		WebRequest request = mock(WebRequest.class);
@@ -46,8 +64,8 @@ class GlobalExceptionHandlerTest {
 		GlobalResponse globalResponse = (GlobalResponse)(response.getBody());
 		assertInstanceOf(ErrorResponse.class, globalResponse.data());
 		ErrorResponse errorResponse = (ErrorResponse)(globalResponse.data());
-		assertEquals("C010", errorResponse.code());
-		assertEquals("유효하지 않은 method 인자 입니다.", errorResponse.message());
+		assertEquals(ErrorCode.METHOD_ARGUMENT_INVALID.getCode(), errorResponse.code());
+		assertTrue(errorResponse.message().contains(ErrorCode.METHOD_ARGUMENT_INVALID.getMessage()));
 	}
 
 	@Test

--- a/src/test/java/taco/klkl/global/error/GlobalExceptionHandlerTest.java
+++ b/src/test/java/taco/klkl/global/error/GlobalExceptionHandlerTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
@@ -114,6 +115,32 @@ class GlobalExceptionHandlerTest {
 		ErrorResponse errorResponse = (ErrorResponse)(globalResponse.data());
 		assertEquals("C012", errorResponse.code());
 		assertEquals("서버에 문제가 발생했습니다. 관리자에게 문의해주세요.", errorResponse.message());
+	}
+
+	@Test
+	@DisplayName("HttpMessageNotReadableException이 발생한 경우")
+	void httpMessageNotReadableOccurred() {
+		// given
+		HttpMessageNotReadableException exception = mock(HttpMessageNotReadableException.class);
+		when(exception.getMessage()).thenReturn("Error reading HTTP message");
+
+		HttpHeaders headers = new HttpHeaders();
+		HttpStatus status = HttpStatus.BAD_REQUEST;
+		WebRequest request = mock(WebRequest.class);
+
+		// when
+		ResponseEntity<Object> response = globalExceptionHandler.handleHttpMessageNotReadable(
+			exception, headers, status, request);
+
+		// then
+		assertNotNull(response);
+		assertEquals(ErrorCode.HTTP_MESSAGE_NOT_READABLE.getStatus(), response.getStatusCode());
+		assertInstanceOf(GlobalResponse.class, response.getBody());
+		GlobalResponse globalResponse = (GlobalResponse)(response.getBody());
+		assertInstanceOf(ErrorResponse.class, globalResponse.data());
+		ErrorResponse errorResponse = (ErrorResponse)(globalResponse.data());
+		assertEquals(ErrorCode.HTTP_MESSAGE_NOT_READABLE.getCode(), errorResponse.code());
+		assertEquals(ErrorCode.HTTP_MESSAGE_NOT_READABLE.getMessage(), errorResponse.message());
 	}
 
 	@Test


### PR DESCRIPTION
## 📌 연관된 이슈
- **[KL-68/상품 정보 수정 API 구현](https://ohhamma.atlassian.net/browse/KL-68)**

## 📝 작업 내용
- 상품 정보 수정 API 구현
- 관련 테스트코드 작성

## 🌳 작업 브랜치명
- `KL-68/상품-정보-수정-api-구현`

## 📸 스크린샷 (선택)

## 💬 리뷰 요구사항 (선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new endpoint for updating product information with PATCH requests, allowing partial updates to product details.
	- Enhanced product creation and update functionalities with improved validation for incoming requests.

- **Bug Fixes**
	- Improved error handling for malformed requests, enhancing clarity and robustness in error reporting.

- **Tests**
	- Expanded test coverage to include scenarios for product updates and validation, ensuring robustness in functionality.

- **Documentation**
	- Updated validation messages and constraints for product-related data to improve data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->