### PR TITLE
refactor(KL-120): change category entity field to enum class

### DIFF
--- a/src/main/java/taco/klkl/domain/category/controller/CategoryController.java
+++ b/src/main/java/taco/klkl/domain/category/controller/CategoryController.java
@@ -24,7 +24,7 @@ public class CategoryController {
 
 	@GetMapping
 	public ResponseEntity<List<CategoryResponseDto>> getCategory() {
-		List<CategoryResponseDto> categoryResponsDtos = categoryService.getCategories();
-		return ResponseEntity.ok().body(categoryResponsDtos);
+		List<CategoryResponseDto> categoryResponseDto = categoryService.getCategories();
+		return ResponseEntity.ok().body(categoryResponseDto);
 	}
 }

--- a/src/main/java/taco/klkl/domain/category/convert/CategoryNameConverter.java
+++ b/src/main/java/taco/klkl/domain/category/convert/CategoryNameConverter.java
@@ -1,0 +1,19 @@
+package taco.klkl.domain.category.convert;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import taco.klkl.domain.category.domain.CategoryName;
+
+@Converter(autoApply = true)
+public class CategoryNameConverter implements AttributeConverter<CategoryName, String> {
+
+	@Override
+	public String convertToDatabaseColumn(CategoryName categoryName) {
+		return categoryName.getName();
+	}
+
+	@Override
+	public CategoryName convertToEntityAttribute(String name) {
+		return CategoryName.getByName(name);
+	}
+}

--- a/src/main/java/taco/klkl/domain/category/domain/Category.java
+++ b/src/main/java/taco/klkl/domain/category/domain/Category.java
@@ -18,14 +18,14 @@ public class Category {
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	private Long id;
 
-	@Column(name = "name", nullable = false, unique = true, length = 20)
-	private String name;
+	@Column(name = "name")
+	private CategoryName name;
 
-	private Category(String name) {
+	private Category(CategoryName name) {
 		this.name = name;
 	}
 
-	public static Category of(String name) {
+	public static Category of(CategoryName name) {
 		return new Category(name);
 	}
 }

--- a/src/main/java/taco/klkl/domain/category/domain/CategoryName.java
+++ b/src/main/java/taco/klkl/domain/category/domain/CategoryName.java
@@ -1,0 +1,25 @@
+package taco.klkl.domain.category.domain;
+
+import java.util.Arrays;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum CategoryName {
+	FOOD("식품"),
+	CLOTHES("의류"),
+	SUNDRIES("잡화"),
+	COSMETICS("화장품"),
+	NONE("");
+
+	private final String name;
+
+	public static CategoryName getByName(String name) {
+		return Arrays.stream(values())
+			.filter(categoryName -> categoryName.getName().equals(name))
+			.findFirst()
+			.orElse(NONE);
+	}
+}

--- a/src/main/java/taco/klkl/domain/category/dto/response/CategoryResponseDto.java
+++ b/src/main/java/taco/klkl/domain/category/dto/response/CategoryResponseDto.java
@@ -1,10 +1,12 @@
 package taco.klkl.domain.category.dto.response;
 
+import taco.klkl.domain.category.domain.CategoryName;
+
 public record CategoryResponseDto(
 	Long id,
 	String name
 ) {
-	public static CategoryResponseDto of(Long id, String name) {
-		return new CategoryResponseDto(id, name);
+	public static CategoryResponseDto of(Long id, CategoryName categoryName) {
+		return new CategoryResponseDto(id, categoryName.getName());
 	}
 }

--- a/src/test/java/taco/klkl/domain/category/controller/CategoryControllerTest.java
+++ b/src/test/java/taco/klkl/domain/category/controller/CategoryControllerTest.java
@@ -32,13 +32,13 @@ public class CategoryControllerTest {
 	@DisplayName("카테고리 컨트롤러 GlobalResponse로 Wrapping되어 나오는지 Test")
 	public void testGetCategory() throws Exception {
 		// given
-		List<CategoryResponseDto> categoryResponsDtos = Arrays.asList(
+		List<CategoryResponseDto> categoryResponseDto = Arrays.asList(
 			new CategoryResponseDto(1L, "Category1"),
 			new CategoryResponseDto(2L, "Category2")
 		);
 
 		// when
-		when(categoryService.getCategories()).thenReturn(categoryResponsDtos);
+		when(categoryService.getCategories()).thenReturn(categoryResponseDto);
 
 		// then
 		mockMvc.perform(get("/v1/categories")

--- a/src/test/java/taco/klkl/domain/category/integration/CategoryIntegrationTest.java
+++ b/src/test/java/taco/klkl/domain/category/integration/CategoryIntegrationTest.java
@@ -33,13 +33,13 @@ class CategoryIntegrationTest {
 	@DisplayName("카테고리 목록 반환 API 통합 Test")
 	void testGetAllCategories() throws Exception {
 		// given
-		List<CategoryResponseDto> categoryResponsDtos = categoryService.getCategories();
+		List<CategoryResponseDto> categoryResponseDto = categoryService.getCategories();
 
 		//then
 		mockMvc.perform(get("/v1/categories")
 				.contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.data", hasSize(categoryResponsDtos.size())))
+			.andExpect(jsonPath("$.data", hasSize(categoryResponseDto.size())))
 			.andExpect(jsonPath("$.isSuccess", is(true)))
 			.andExpect(jsonPath("$.code", is("C000")));
 	}

--- a/src/test/java/taco/klkl/domain/category/service/CategoryServiceTest.java
+++ b/src/test/java/taco/klkl/domain/category/service/CategoryServiceTest.java
@@ -16,6 +16,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import jakarta.transaction.Transactional;
 import taco.klkl.domain.category.dao.CategoryRepository;
 import taco.klkl.domain.category.domain.Category;
+import taco.klkl.domain.category.domain.CategoryName;
 import taco.klkl.domain.category.dto.response.CategoryResponseDto;
 
 @ExtendWith(MockitoExtension.class)
@@ -32,8 +33,8 @@ class CategoryServiceTest {
 	@DisplayName("카테고리 Service CategoryResponse(DTO)에 담겨 나오는지 Test")
 	void testGetCategories() {
 		// given
-		Category category1 = Category.of("Category 1");
-		Category category2 = Category.of("Category 2");
+		Category category1 = Category.of(CategoryName.CLOTHES);
+		Category category2 = Category.of(CategoryName.FOOD);
 		List<Category> categories = Arrays.asList(category1, category2);
 
 		when(categoryRepository.findAll()).thenReturn(categories);
@@ -45,8 +46,8 @@ class CategoryServiceTest {
 		assertNotNull(result);
 		assertEquals(2, result.size());
 
-		assertEquals("Category 1", result.get(0).name());
-		assertEquals("Category 2", result.get(1).name());
+		assertEquals(CategoryName.CLOTHES.getName(), result.get(0).name());
+		assertEquals(CategoryName.FOOD.getName(), result.get(1).name());
 
 		verify(categoryRepository, times(1)).findAll();
 	}

--- a/src/test/java/taco/klkl/domain/subcategory/service/SubcategoryServiceTest.java
+++ b/src/test/java/taco/klkl/domain/subcategory/service/SubcategoryServiceTest.java
@@ -16,6 +16,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import jakarta.transaction.Transactional;
 import taco.klkl.domain.category.domain.Category;
+import taco.klkl.domain.category.domain.CategoryName;
 import taco.klkl.domain.subcategory.dao.SubcategoryRepository;
 import taco.klkl.domain.subcategory.domain.Subcategory;
 import taco.klkl.domain.subcategory.domain.SubcategoryName;
@@ -37,7 +38,7 @@ public class SubcategoryServiceTest {
 	@DisplayName("Valid한 카테고리ID 입력시 해당하는 서브카테고리를 반환하는지 테스트")
 	void testGetSubcategoriesWithValidCategoryId() {
 		//given
-		Category category = Category.of("Category1");
+		Category category = Category.of(CategoryName.FOOD);
 		Subcategory subcategory1 = Subcategory.of(category, SubcategoryName.DRESS);
 		Subcategory subcategory2 = Subcategory.of(category, SubcategoryName.HAIR_CARE);
 		List<Subcategory> subcategories = Arrays.asList(subcategory1, subcategory2);


### PR DESCRIPTION
## 📌 연관된 이슈
[카테고리 entity 필드 enum으로 교체](https://ohhamma.atlassian.net/browse/KL-120)

## 📝 작업 내용
- Category entity의 name field를 Enum class로 변경
- CategoryName enum class와 converter 생성.
- ResponsDto를 Respons'e'Dto로 변경.
- test code를 enum class에 맞게 수정.

## 🌳 작업 브랜치명
`KL-120/카테고리-entity-필드-enum으로-교체`

## 📸 스크린샷 (선택)

## 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요