### PR TITLE
feat(KL-70): delete Product API

### DIFF
--- a/src/main/java/taco/klkl/domain/product/controller/ProductController.java
+++ b/src/main/java/taco/klkl/domain/product/controller/ProductController.java
@@ -2,6 +2,7 @@ package taco.klkl.domain.product.controller;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -29,7 +30,9 @@ public class ProductController {
 
 	@GetMapping("/{id}")
 	@Operation(summary = "상품 상세 조회", description = "상품 상세 정보를 조회합니다.")
-	public ResponseEntity<ProductDetailResponseDto> getProductInfoById(@PathVariable Long id) {
+	public ResponseEntity<ProductDetailResponseDto> getProductInfoById(
+		@PathVariable Long id
+	) {
 		ProductDetailResponseDto productDto = productService.getProductInfoById(id);
 		return ResponseEntity.ok().body(productDto);
 	}
@@ -51,5 +54,14 @@ public class ProductController {
 	) {
 		ProductDetailResponseDto productDto = productService.updateProduct(id, updateRequest);
 		return ResponseEntity.ok().body(productDto);
+	}
+
+	@DeleteMapping("/{id}")
+	@Operation(summary = "상품 삭제", description = "상품을 삭제합니다.")
+	public ResponseEntity<ProductDetailResponseDto> deleteProduct(
+		@PathVariable Long id
+	) {
+		productService.deleteProduct(id);
+		return ResponseEntity.noContent().build();
 	}
 }

--- a/src/main/java/taco/klkl/domain/product/domain/Product.java
+++ b/src/main/java/taco/klkl/domain/product/domain/Product.java
@@ -72,7 +72,10 @@ public class Product {
 	)
 	private LocalDateTime createdAt;
 
-	@Column(name = "price")
+	@Column(
+		name = "price",
+		nullable = false
+	)
 	@ColumnDefault(DefaultConstants.DEFAULT_INT_STRING)
 	private Integer price;
 

--- a/src/main/java/taco/klkl/domain/product/dto/request/ProductCreateRequestDto.java
+++ b/src/main/java/taco/klkl/domain/product/dto/request/ProductCreateRequestDto.java
@@ -29,9 +29,11 @@ public record ProductCreateRequestDto(
 	@Size(max = ProductConstants.DESCRIPTION_MAX_LENGTH, message = ProductValidationMessages.DESCRIPTION_SIZE)
 	String description,
 
+	@NotNull(message = ProductValidationMessages.ADDRESS_NOT_NULL)
 	@Size(max = ProductConstants.ADDRESS_MAX_LENGTH, message = ProductValidationMessages.ADDRESS_SIZE)
 	String address,
 
+	@NotNull(message = ProductValidationMessages.PRICE_NOT_NULL)
 	@PositiveOrZero(message = ProductValidationMessages.PRICE_POSITIVE_OR_ZERO)
 	Integer price,
 

--- a/src/main/java/taco/klkl/domain/product/service/ProductService.java
+++ b/src/main/java/taco/klkl/domain/product/service/ProductService.java
@@ -11,7 +11,6 @@ import taco.klkl.domain.product.dto.request.ProductUpdateRequestDto;
 import taco.klkl.domain.product.dto.response.ProductDetailResponseDto;
 import taco.klkl.domain.product.exception.ProductNotFoundException;
 import taco.klkl.domain.user.domain.User;
-import taco.klkl.global.common.constants.ProductConstants;
 import taco.klkl.global.util.UserUtil;
 
 @Service
@@ -41,6 +40,13 @@ public class ProductService {
 			.orElseThrow(ProductNotFoundException::new);
 		product.update(productDto);
 		return ProductDetailResponseDto.from(product);
+	}
+
+	@Transactional
+	public void deleteProduct(final Long id) {
+		final Product product = productRepository.findById(id)
+			.orElseThrow(ProductNotFoundException::new);
+		productRepository.delete(product);
 	}
 
 	private Product createProductEntity(final ProductCreateRequestDto productDto) {

--- a/src/main/java/taco/klkl/global/common/constants/ProductConstants.java
+++ b/src/main/java/taco/klkl/global/common/constants/ProductConstants.java
@@ -1,5 +1,7 @@
 package taco.klkl.global.common.constants;
 
+import taco.klkl.domain.product.domain.Product;
+
 public final class ProductConstants {
 
 	public static final int DEFAULT_PRICE = 0;
@@ -9,6 +11,17 @@ public final class ProductConstants {
 	public static final int NAME_MAX_LENGTH = 100;
 	public static final int DESCRIPTION_MAX_LENGTH = 2000;
 	public static final int ADDRESS_MAX_LENGTH = 100;
+
+	public static final Product TEST_PRODUCT = Product.of(
+		UserConstants.TEST_USER,
+		"testProduct",
+		"testDescription",
+		"testAddress",
+		1000,
+		1L,
+		2L,
+		3L
+	);
 
 	private ProductConstants() {
 	}

--- a/src/main/java/taco/klkl/global/common/constants/ProductValidationMessages.java
+++ b/src/main/java/taco/klkl/global/common/constants/ProductValidationMessages.java
@@ -10,8 +10,10 @@ public final class ProductValidationMessages {
 	public static final String DESCRIPTION_NOT_BLANK = "상품 설명은 비어있을 수 없습니다.";
 	public static final String DESCRIPTION_SIZE = "상품 설명은 2000자 이하여야 합니다.";
 
+	public static final String ADDRESS_NOT_NULL = "주소는 필수 항목입니다.";
 	public static final String ADDRESS_SIZE = "주소는 100자 이하여야 합니다.";
 
+	public static final String PRICE_NOT_NULL = "가격은 필수 항목입니다.";
 	public static final String PRICE_POSITIVE_OR_ZERO = "가격은 0 이상이어야 합니다.";
 
 	public static final String CITY_ID_NOT_NULL = "도시 ID는 필수 항목입니다.";

--- a/src/test/java/taco/klkl/domain/product/dto/request/ProductCreateRequestDtoTest.java
+++ b/src/test/java/taco/klkl/domain/product/dto/request/ProductCreateRequestDtoTest.java
@@ -14,6 +14,7 @@ import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import jakarta.validation.ValidatorFactory;
+import taco.klkl.global.common.constants.ProductConstants;
 import taco.klkl.global.common.constants.ProductValidationMessages;
 
 class ProductCreateRequestDtoTest {
@@ -167,6 +168,63 @@ class ProductCreateRequestDtoTest {
 		assertEquals(ProductValidationMessages.DESCRIPTION_SIZE, violations.iterator().next().getMessage());
 	}
 
+	@Test
+	@DisplayName("주소가 null일 때 검증 실패")
+	void nullAddress() {
+		ProductCreateRequestDto dto = new ProductCreateRequestDto(
+			"Valid Product Name",
+			"Valid product description",
+			null,
+			100,
+			1L,
+			2L,
+			3L
+		);
+
+		Set<ConstraintViolation<ProductCreateRequestDto>> violations = validator.validate(dto);
+		assertFalse(violations.isEmpty());
+
+		boolean foundNotNullMessage = violations.stream()
+			.anyMatch(violation -> violation.getMessage().equals(ProductValidationMessages.ADDRESS_NOT_NULL));
+		assertTrue(foundNotNullMessage, "Expected ADDRESS_NOT_NULL message not found");
+	}
+
+	@Test
+	@DisplayName("주소가 빈 문자열일 때 검증 통과")
+	void emptyAddress() {
+		ProductCreateRequestDto dto = new ProductCreateRequestDto(
+			"Valid Product Name",
+			"Valid product description",
+			"",
+			100,
+			1L,
+			2L,
+			3L
+		);
+
+		Set<ConstraintViolation<ProductCreateRequestDto>> violations = validator.validate(dto);
+		assertTrue(violations.isEmpty());
+	}
+
+	@ParameterizedTest
+	@ValueSource(ints = {0, 1, ProductConstants.ADDRESS_MAX_LENGTH})
+	@DisplayName("주소가 최대 길이 이하일 때 검증 통과")
+	void addressMaxLength(int addressLength) {
+		String address = "a".repeat(addressLength);
+		ProductCreateRequestDto dto = new ProductCreateRequestDto(
+			"Valid Product Name",
+			"Valid product description",
+			address,
+			100,
+			1L,
+			2L,
+			3L
+		);
+
+		Set<ConstraintViolation<ProductCreateRequestDto>> violations = validator.validate(dto);
+		assertTrue(violations.isEmpty());
+	}
+
 	@ParameterizedTest
 	@ValueSource(ints = {101, 200, 500})
 	@DisplayName("주소가 최대 길이를 초과할 때 검증 실패")
@@ -185,6 +243,45 @@ class ProductCreateRequestDtoTest {
 		Set<ConstraintViolation<ProductCreateRequestDto>> violations = validator.validate(dto);
 		assertFalse(violations.isEmpty());
 		assertEquals(ProductValidationMessages.ADDRESS_SIZE, violations.iterator().next().getMessage());
+	}
+
+	@Test
+	@DisplayName("가격이 null일 때 검증 실패")
+	void nullPrice() {
+		ProductCreateRequestDto dto = new ProductCreateRequestDto(
+			"Valid Product Name",
+			"Valid product description",
+			"Valid address",
+			null,
+			1L,
+			2L,
+			3L
+		);
+
+		Set<ConstraintViolation<ProductCreateRequestDto>> violations = validator.validate(dto);
+		assertFalse(violations.isEmpty());
+
+		boolean foundNotNullMessage = violations.stream()
+			.anyMatch(violation -> violation.getMessage().equals(ProductValidationMessages.PRICE_NOT_NULL));
+		assertTrue(foundNotNullMessage, "Expected PRICE_NOT_NULL message not found");
+	}
+
+	@ParameterizedTest
+	@ValueSource(ints = {0, 100, 1000})
+	@DisplayName("가격이 0 이상일 때 검증 통과")
+	void zeroPriceIsValid() {
+		ProductCreateRequestDto dto = new ProductCreateRequestDto(
+			"Valid Product Name",
+			"Valid product description",
+			"Valid address",
+			0,
+			1L,
+			2L,
+			3L
+		);
+
+		Set<ConstraintViolation<ProductCreateRequestDto>> violations = validator.validate(dto);
+		assertTrue(violations.isEmpty());
 	}
 
 	@ParameterizedTest

--- a/src/test/java/taco/klkl/domain/product/dto/request/ProductCreateRequestDtoTest.java
+++ b/src/test/java/taco/klkl/domain/product/dto/request/ProductCreateRequestDtoTest.java
@@ -29,7 +29,7 @@ class ProductCreateRequestDtoTest {
 
 	@Test
 	@DisplayName("유효한 ProductCreateRequestDto 생성 시 검증 통과")
-	void validProductCreateRequestDto() {
+	void testValidProductCreateRequestDto() {
 		ProductCreateRequestDto dto = new ProductCreateRequestDto(
 			"Valid Product Name",
 			"Valid product description",
@@ -46,7 +46,7 @@ class ProductCreateRequestDtoTest {
 
 	@Test
 	@DisplayName("상품명이 null일 때 검증 실패")
-	void nullProductName() {
+	void testNullProductName() {
 		ProductCreateRequestDto dto = new ProductCreateRequestDto(
 			null,
 			"Valid product description",
@@ -67,7 +67,7 @@ class ProductCreateRequestDtoTest {
 
 	@Test
 	@DisplayName("상품명이 빈 문자열일 때 검증 실패")
-	void emptyProductName() {
+	void testEmptyProductName() {
 		ProductCreateRequestDto dto = new ProductCreateRequestDto(
 			"",
 			"Valid product description",
@@ -89,7 +89,7 @@ class ProductCreateRequestDtoTest {
 	@ParameterizedTest
 	@ValueSource(ints = {101, 200, 1000})
 	@DisplayName("상품명이 최대 길이를 초과할 때 검증 실패")
-	void productNameExceedsMaxLength(int nameLength) {
+	void testProductNameOverMaxLength(int nameLength) {
 		String longName = "a".repeat(nameLength);
 		ProductCreateRequestDto dto = new ProductCreateRequestDto(
 			longName,
@@ -108,7 +108,7 @@ class ProductCreateRequestDtoTest {
 
 	@Test
 	@DisplayName("상품 설명이 null일 때 검증 실패")
-	void nullProductDescription() {
+	void testNullProductDescription() {
 		ProductCreateRequestDto dto = new ProductCreateRequestDto(
 			"Valid Product Name",
 			null,
@@ -129,7 +129,7 @@ class ProductCreateRequestDtoTest {
 
 	@Test
 	@DisplayName("상품 설명이 빈 문자열일 때 검증 실패")
-	void emptyProductDescription() {
+	void testEmptyProductDescription() {
 		ProductCreateRequestDto dto = new ProductCreateRequestDto(
 			"Valid Product Name",
 			"",
@@ -151,7 +151,7 @@ class ProductCreateRequestDtoTest {
 	@ParameterizedTest
 	@ValueSource(ints = {2001, 3000, 5000})
 	@DisplayName("상품 설명이 최대 길이를 초과할 때 검증 실패")
-	void productDescriptionExceedsMaxLength(int descriptionLength) {
+	void testProductDescriptionOverMaxLength(int descriptionLength) {
 		String longDescription = "a".repeat(descriptionLength);
 		ProductCreateRequestDto dto = new ProductCreateRequestDto(
 			"Valid Product Name",
@@ -170,7 +170,7 @@ class ProductCreateRequestDtoTest {
 
 	@Test
 	@DisplayName("주소가 null일 때 검증 실패")
-	void nullAddress() {
+	void testNullAddress() {
 		ProductCreateRequestDto dto = new ProductCreateRequestDto(
 			"Valid Product Name",
 			"Valid product description",
@@ -191,7 +191,7 @@ class ProductCreateRequestDtoTest {
 
 	@Test
 	@DisplayName("주소가 빈 문자열일 때 검증 통과")
-	void emptyAddress() {
+	void testEmptyAddress() {
 		ProductCreateRequestDto dto = new ProductCreateRequestDto(
 			"Valid Product Name",
 			"Valid product description",
@@ -209,7 +209,7 @@ class ProductCreateRequestDtoTest {
 	@ParameterizedTest
 	@ValueSource(ints = {0, 1, ProductConstants.ADDRESS_MAX_LENGTH})
 	@DisplayName("주소가 최대 길이 이하일 때 검증 통과")
-	void addressMaxLength(int addressLength) {
+	void testAddressUnderMaxLength(int addressLength) {
 		String address = "a".repeat(addressLength);
 		ProductCreateRequestDto dto = new ProductCreateRequestDto(
 			"Valid Product Name",
@@ -228,7 +228,7 @@ class ProductCreateRequestDtoTest {
 	@ParameterizedTest
 	@ValueSource(ints = {101, 200, 500})
 	@DisplayName("주소가 최대 길이를 초과할 때 검증 실패")
-	void addressExceedsMaxLength(int addressLength) {
+	void testAddressOverMaxLength(int addressLength) {
 		String longAddress = "a".repeat(addressLength);
 		ProductCreateRequestDto dto = new ProductCreateRequestDto(
 			"Valid Product Name",
@@ -247,7 +247,7 @@ class ProductCreateRequestDtoTest {
 
 	@Test
 	@DisplayName("가격이 null일 때 검증 실패")
-	void nullPrice() {
+	void testNullPrice() {
 		ProductCreateRequestDto dto = new ProductCreateRequestDto(
 			"Valid Product Name",
 			"Valid product description",
@@ -269,7 +269,7 @@ class ProductCreateRequestDtoTest {
 	@ParameterizedTest
 	@ValueSource(ints = {0, 100, 1000})
 	@DisplayName("가격이 0 이상일 때 검증 통과")
-	void zeroPriceIsValid() {
+	void testZeroOrPositivePrice() {
 		ProductCreateRequestDto dto = new ProductCreateRequestDto(
 			"Valid Product Name",
 			"Valid product description",
@@ -287,7 +287,7 @@ class ProductCreateRequestDtoTest {
 	@ParameterizedTest
 	@ValueSource(ints = {-1, -100, -1000})
 	@DisplayName("가격이 음수일 때 검증 실패")
-	void negativePrice(int price) {
+	void testNegativePrice(int price) {
 		ProductCreateRequestDto dto = new ProductCreateRequestDto(
 			"Valid Product Name",
 			"Valid product description",
@@ -305,7 +305,7 @@ class ProductCreateRequestDtoTest {
 
 	@Test
 	@DisplayName("도시 ID가 null일 때 검증 실패")
-	void nullCityId() {
+	void testNullCityId() {
 		ProductCreateRequestDto dto = new ProductCreateRequestDto(
 			"Valid Product Name",
 			"Valid product description",
@@ -323,7 +323,7 @@ class ProductCreateRequestDtoTest {
 
 	@Test
 	@DisplayName("상품 소분류 ID가 null일 때 검증 실패")
-	void nullSubcategoryId() {
+	void testNullSubcategoryId() {
 		ProductCreateRequestDto dto = new ProductCreateRequestDto(
 			"Valid Product Name",
 			"Valid product description",
@@ -341,7 +341,7 @@ class ProductCreateRequestDtoTest {
 
 	@Test
 	@DisplayName("통화 ID가 null일 때 검증 실패")
-	void nullCurrencyId() {
+	void testNullCurrencyId() {
 		ProductCreateRequestDto dto = new ProductCreateRequestDto(
 			"Valid Product Name",
 			"Valid product description",

--- a/src/test/java/taco/klkl/domain/product/service/ProductServiceTest.java
+++ b/src/test/java/taco/klkl/domain/product/service/ProductServiceTest.java
@@ -46,24 +46,8 @@ class ProductServiceTest {
 	void testGetProductInfoById_Success() {
 		// given
 		Long productId = 1L;
-		String name = "맛있는 곤약젤리";
-		String description = "탱글탱글 맛있는 곤약젤리";
-		String address = "신사이바시 메가돈키호테";
-		Integer price = 100;
-		Long cityId = 2L;
-		Long subcategoryId = 3L;
-		Long currencyId = 4L;
 
-		Product product = Product.of(
-			user,
-			name,
-			description,
-			address,
-			price,
-			cityId,
-			subcategoryId,
-			currencyId
-		);
+		Product product = ProductConstants.TEST_PRODUCT;
 		when(productRepository.findById(productId)).thenReturn(Optional.of(product));
 
 		// when
@@ -72,14 +56,14 @@ class ProductServiceTest {
 		// then
 		assertThat(responseDto).isNotNull();
 		assertThat(responseDto.userId()).isEqualTo(user.getId());
-		assertThat(responseDto.name()).isEqualTo(name);
-		assertThat(responseDto.description()).isEqualTo(description);
-		assertThat(responseDto.address()).isEqualTo(address);
+		assertThat(responseDto.name()).isEqualTo(product.getName());
+		assertThat(responseDto.description()).isEqualTo(product.getDescription());
+		assertThat(responseDto.address()).isEqualTo(product.getAddress());
 		assertThat(responseDto.likeCount()).isEqualTo(ProductConstants.DEFAULT_LIKE_COUNT);
-		assertThat(responseDto.price()).isEqualTo(price);
-		assertThat(responseDto.cityId()).isEqualTo(cityId);
-		assertThat(responseDto.subcategoryId()).isEqualTo(subcategoryId);
-		assertThat(responseDto.currencyId()).isEqualTo(currencyId);
+		assertThat(responseDto.price()).isEqualTo(product.getPrice());
+		assertThat(responseDto.cityId()).isEqualTo(product.getCityId());
+		assertThat(responseDto.subcategoryId()).isEqualTo(product.getSubcategoryId());
+		assertThat(responseDto.currencyId()).isEqualTo(product.getCurrencyId());
 
 		verify(productRepository).findById(productId);
 	}
@@ -105,51 +89,34 @@ class ProductServiceTest {
 	@DisplayName("상품을 생성할 때, 정상적으로 ProductDetailResponseDto를 반환해야 한다.")
 	void testCreateProduct_Success() {
 		// given
-		ProductCreateRequestDto productDto = new ProductCreateRequestDto(
-			"맛있는 곤약젤리",
-			"탱글탱글 맛있는 곤약젤리",
-			"신사이바시 메가돈키호테",
-			100,
-			2L,
-			3L,
-			4L
+		Product product = ProductConstants.TEST_PRODUCT;
+		ProductCreateRequestDto requestDto = new ProductCreateRequestDto(
+			product.getName(),
+			product.getDescription(),
+			product.getAddress(),
+			product.getPrice(),
+			product.getCityId(),
+			product.getSubcategoryId(),
+			product.getCurrencyId()
 		);
 
-		String name = productDto.name();
-		String description = productDto.description();
-		String address = productDto.address();
-		Integer price = productDto.price();
-		Long cityId = productDto.cityId();
-		Long subcategoryId = productDto.subcategoryId();
-		Long currencyId = productDto.currencyId();
-
-		Product product = Product.of(
-			user,
-			name,
-			description,
-			address,
-			price,
-			cityId,
-			subcategoryId,
-			currencyId
-		);
 		when(userUtil.findTestUser()).thenReturn(user);
 		when(productRepository.save(any(Product.class))).thenReturn(product);
 
 		// when
-		ProductDetailResponseDto responseDto = productService.createProduct(productDto);
+		ProductDetailResponseDto responseDto = productService.createProduct(requestDto);
 
 		// then
 		assertThat(responseDto).isNotNull();
 		assertThat(responseDto.userId()).isEqualTo(user.getId());
-		assertThat(responseDto.name()).isEqualTo(name);
-		assertThat(responseDto.description()).isEqualTo(description);
-		assertThat(responseDto.address()).isEqualTo(address);
+		assertThat(responseDto.name()).isEqualTo(requestDto.name());
+		assertThat(responseDto.description()).isEqualTo(requestDto.description());
+		assertThat(responseDto.address()).isEqualTo(requestDto.address());
 		assertThat(responseDto.likeCount()).isEqualTo(ProductConstants.DEFAULT_LIKE_COUNT);
-		assertThat(responseDto.price()).isEqualTo(price);
-		assertThat(responseDto.cityId()).isEqualTo(cityId);
-		assertThat(responseDto.subcategoryId()).isEqualTo(subcategoryId);
-		assertThat(responseDto.currencyId()).isEqualTo(currencyId);
+		assertThat(responseDto.price()).isEqualTo(requestDto.price());
+		assertThat(responseDto.cityId()).isEqualTo(requestDto.cityId());
+		assertThat(responseDto.subcategoryId()).isEqualTo(requestDto.subcategoryId());
+		assertThat(responseDto.currencyId()).isEqualTo(requestDto.currencyId());
 
 		verify(productRepository).save(any(Product.class));
 	}
@@ -159,16 +126,7 @@ class ProductServiceTest {
 	void testUpdateProduct_Success() {
 		// given
 		Long productId = 1L;
-		Product existingProduct = Product.of(
-			user,
-			"Original Name",
-			"Original Description",
-			"Original Address",
-			100,
-			1L,
-			1L,
-			1L
-		);
+		Product existingProduct = ProductConstants.TEST_PRODUCT;
 
 		ProductUpdateRequestDto updateDto = new ProductUpdateRequestDto(
 			"Updated Name",
@@ -225,5 +183,50 @@ class ProductServiceTest {
 		assertThat(exception).isNotNull();
 		verify(productRepository).findById(productId);
 		verify(productRepository, never()).save(any(Product.class));
+	}
+
+	@Test
+	@DisplayName("존재하는 제품 삭제 성공")
+	void deleteExistingProduct() {
+		// Given
+		Long productId = 1L;
+		Product product = ProductConstants.TEST_PRODUCT;
+		when(productRepository.findById(productId)).thenReturn(Optional.of(product));
+
+		// When
+		assertDoesNotThrow(() -> productService.deleteProduct(productId));
+
+		// Then
+		verify(productRepository).findById(productId);
+		verify(productRepository).delete(product);
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 제품 삭제 시 예외 발생")
+	void deleteNonExistingProduct() {
+		// Given
+		Long nonExistingProductId = 999L;
+		when(productRepository.findById(nonExistingProductId)).thenReturn(Optional.empty());
+
+		// When & Then
+		assertThrows(ProductNotFoundException.class, () -> productService.deleteProduct(nonExistingProductId));
+		verify(productRepository).findById(nonExistingProductId);
+		verify(productRepository, never()).delete(any(Product.class));
+	}
+
+	@Test
+	@DisplayName("제품 삭제 시 repository 메소드 호출 확인")
+	void verifyRepositoryMethodsCalledOnDelete() {
+		// Given
+		Long productId = 1L;
+		Product product = ProductConstants.TEST_PRODUCT;
+		when(productRepository.findById(productId)).thenReturn(Optional.of(product));
+
+		// When
+		productService.deleteProduct(productId);
+
+		// Then
+		verify(productRepository).findById(productId);
+		verify(productRepository).delete(product);
 	}
 }


### PR DESCRIPTION
## 📌 연관된 이슈
- **[KL-70/상품 삭제 API 구현](https://ohhamma.atlassian.net/browse/KL-70)**

## 📝 작업 내용
- 상품 삭제 API 및 서비스 구현
- 상품 필드 모두 null 미허용

## 🌳 작업 브랜치명
- `KL-70/상품-삭제-api-구현`

## 📸 스크린샷 (선택)

## 💬 리뷰 요구사항 (선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new endpoint for deleting products, enhancing product management capabilities.
	- Added validation for address and price fields in product creation requests, ensuring data integrity.

- **Bug Fixes**
	- Improved readability of code in the product controller.

- **Tests**
	- Enhanced test coverage for product deletion functionality and input validation in various test classes.

- **Chores**
	- Added new constants for validation messages related to product attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->