### PR TITLE
feat(KL-125): get all products

### DIFF
--- a/src/main/java/taco/klkl/domain/product/controller/ProductController.java
+++ b/src/main/java/taco/klkl/domain/product/controller/ProductController.java
@@ -1,5 +1,7 @@
 package taco.klkl.domain.product.controller;
 
+import java.util.List;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -18,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 import taco.klkl.domain.product.dto.request.ProductCreateRequestDto;
 import taco.klkl.domain.product.dto.request.ProductUpdateRequestDto;
 import taco.klkl.domain.product.dto.response.ProductDetailResponseDto;
+import taco.klkl.domain.product.dto.response.ProductSimpleResponseDto;
 import taco.klkl.domain.product.service.ProductService;
 
 @RestController
@@ -28,13 +31,20 @@ public class ProductController {
 
 	private final ProductService productService;
 
+	@GetMapping
+	@Operation(summary = "상품 목록 조회", description = "상품 목록을 조회합니다.")
+	public ResponseEntity<List<ProductSimpleResponseDto>> getAllProducts() {
+		List<ProductSimpleResponseDto> products = productService.getAllProducts();
+		return ResponseEntity.ok(products);
+	}
+
 	@GetMapping("/{id}")
 	@Operation(summary = "상품 상세 조회", description = "상품 상세 정보를 조회합니다.")
 	public ResponseEntity<ProductDetailResponseDto> getProductById(
 		@PathVariable Long id
 	) {
 		ProductDetailResponseDto productDto = productService.getProductById(id);
-		return ResponseEntity.ok().body(productDto);
+		return ResponseEntity.ok(productDto);
 	}
 
 	@PostMapping
@@ -53,7 +63,7 @@ public class ProductController {
 		@Valid @RequestBody ProductUpdateRequestDto updateRequest
 	) {
 		ProductDetailResponseDto productDto = productService.updateProduct(id, updateRequest);
-		return ResponseEntity.ok().body(productDto);
+		return ResponseEntity.ok(productDto);
 	}
 
 	@DeleteMapping("/{id}")

--- a/src/main/java/taco/klkl/domain/product/controller/ProductController.java
+++ b/src/main/java/taco/klkl/domain/product/controller/ProductController.java
@@ -30,10 +30,10 @@ public class ProductController {
 
 	@GetMapping("/{id}")
 	@Operation(summary = "상품 상세 조회", description = "상품 상세 정보를 조회합니다.")
-	public ResponseEntity<ProductDetailResponseDto> getProductInfoById(
+	public ResponseEntity<ProductDetailResponseDto> getProductById(
 		@PathVariable Long id
 	) {
-		ProductDetailResponseDto productDto = productService.getProductInfoById(id);
+		ProductDetailResponseDto productDto = productService.getProductById(id);
 		return ResponseEntity.ok().body(productDto);
 	}
 

--- a/src/main/java/taco/klkl/domain/product/controller/ProductController.java
+++ b/src/main/java/taco/klkl/domain/product/controller/ProductController.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -47,14 +48,18 @@ public class ProductController {
 
 	@GetMapping("/{id}")
 	@Operation(summary = "상품 상세 조회", description = "상품 상세 정보를 조회합니다.")
-	public ProductDetailResponseDto getProductById(@PathVariable Long id) {
+	public ProductDetailResponseDto getProductById(
+		@PathVariable Long id
+	) {
 		return productService.getProductById(id);
 	}
 
 	@PostMapping
 	@Operation(summary = "상품 등록", description = "상품을 등록합니다.")
 	@ResponseStatus(HttpStatus.CREATED)
-	public ProductDetailResponseDto createProduct(@Valid @RequestBody ProductCreateRequestDto createRequest) {
+	public ProductDetailResponseDto createProduct(
+		@Valid @RequestBody ProductCreateRequestDto createRequest
+	) {
 		return productService.createProduct(createRequest);
 	}
 
@@ -69,8 +74,10 @@ public class ProductController {
 
 	@DeleteMapping("/{id}")
 	@Operation(summary = "상품 삭제", description = "상품을 삭제합니다.")
-	@ResponseStatus(HttpStatus.NO_CONTENT)
-	public void deleteProduct(@PathVariable Long id) {
+	public ResponseEntity<Void> deleteProduct(
+		@PathVariable Long id
+	) {
 		productService.deleteProduct(id);
+		return ResponseEntity.noContent().build();
 	}
 }

--- a/src/main/java/taco/klkl/domain/product/controller/ProductController.java
+++ b/src/main/java/taco/klkl/domain/product/controller/ProductController.java
@@ -2,8 +2,9 @@ package taco.klkl.domain.product.controller;
 
 import java.util.List;
 
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -11,6 +12,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -22,6 +25,7 @@ import taco.klkl.domain.product.dto.request.ProductUpdateRequestDto;
 import taco.klkl.domain.product.dto.response.ProductDetailResponseDto;
 import taco.klkl.domain.product.dto.response.ProductSimpleResponseDto;
 import taco.klkl.domain.product.service.ProductService;
+import taco.klkl.global.common.constants.ProductConstants;
 
 @RestController
 @RequestMapping("/v1/products")
@@ -33,45 +37,40 @@ public class ProductController {
 
 	@GetMapping
 	@Operation(summary = "상품 목록 조회", description = "상품 목록을 조회합니다.")
-	public ResponseEntity<List<ProductSimpleResponseDto>> getAllProducts() {
-		List<ProductSimpleResponseDto> products = productService.getAllProducts();
-		return ResponseEntity.ok(products);
+	public List<ProductSimpleResponseDto> getAllProducts(
+		@RequestParam(defaultValue = ProductConstants.DEFAULT_PAGE_NUMBER) int page,
+		@RequestParam(defaultValue = ProductConstants.DEFAULT_PAGE_SIZE) int size
+	) {
+		Pageable pageable = PageRequest.of(page, size);
+		return productService.getAllProducts(pageable);
 	}
 
 	@GetMapping("/{id}")
 	@Operation(summary = "상품 상세 조회", description = "상품 상세 정보를 조회합니다.")
-	public ResponseEntity<ProductDetailResponseDto> getProductById(
-		@PathVariable Long id
-	) {
-		ProductDetailResponseDto productDto = productService.getProductById(id);
-		return ResponseEntity.ok(productDto);
+	public ProductDetailResponseDto getProductById(@PathVariable Long id) {
+		return productService.getProductById(id);
 	}
 
 	@PostMapping
 	@Operation(summary = "상품 등록", description = "상품을 등록합니다.")
-	public ResponseEntity<ProductDetailResponseDto> createProduct(
-		@Valid @RequestBody ProductCreateRequestDto createRequest
-	) {
-		ProductDetailResponseDto productDto = productService.createProduct(createRequest);
-		return ResponseEntity.status(HttpStatus.CREATED).body(productDto);
+	@ResponseStatus(HttpStatus.CREATED)
+	public ProductDetailResponseDto createProduct(@Valid @RequestBody ProductCreateRequestDto createRequest) {
+		return productService.createProduct(createRequest);
 	}
 
 	@PatchMapping("/{id}")
 	@Operation(summary = "상품 정보 수정", description = "상품 정보를 수정합니다.")
-	public ResponseEntity<ProductDetailResponseDto> updateProduct(
+	public ProductDetailResponseDto updateProduct(
 		@PathVariable Long id,
 		@Valid @RequestBody ProductUpdateRequestDto updateRequest
 	) {
-		ProductDetailResponseDto productDto = productService.updateProduct(id, updateRequest);
-		return ResponseEntity.ok(productDto);
+		return productService.updateProduct(id, updateRequest);
 	}
 
 	@DeleteMapping("/{id}")
 	@Operation(summary = "상품 삭제", description = "상품을 삭제합니다.")
-	public ResponseEntity<ProductDetailResponseDto> deleteProduct(
-		@PathVariable Long id
-	) {
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	public void deleteProduct(@PathVariable Long id) {
 		productService.deleteProduct(id);
-		return ResponseEntity.noContent().build();
 	}
 }

--- a/src/main/java/taco/klkl/domain/product/service/ProductService.java
+++ b/src/main/java/taco/klkl/domain/product/service/ProductService.java
@@ -1,5 +1,7 @@
 package taco.klkl.domain.product.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -9,6 +11,7 @@ import taco.klkl.domain.product.domain.Product;
 import taco.klkl.domain.product.dto.request.ProductCreateRequestDto;
 import taco.klkl.domain.product.dto.request.ProductUpdateRequestDto;
 import taco.klkl.domain.product.dto.response.ProductDetailResponseDto;
+import taco.klkl.domain.product.dto.response.ProductSimpleResponseDto;
 import taco.klkl.domain.product.exception.ProductNotFoundException;
 import taco.klkl.domain.user.domain.User;
 import taco.klkl.global.util.UserUtil;
@@ -20,6 +23,12 @@ public class ProductService {
 
 	private final ProductRepository productRepository;
 	private final UserUtil userUtil;
+
+	public List<ProductSimpleResponseDto> getAllProducts() {
+		return productRepository.findAll().stream()
+			.map(ProductSimpleResponseDto::from)
+			.toList();
+	}
 
 	public ProductDetailResponseDto getProductById(final Long id) {
 		final Product product = productRepository.findById(id)

--- a/src/main/java/taco/klkl/domain/product/service/ProductService.java
+++ b/src/main/java/taco/klkl/domain/product/service/ProductService.java
@@ -21,7 +21,7 @@ public class ProductService {
 	private final ProductRepository productRepository;
 	private final UserUtil userUtil;
 
-	public ProductDetailResponseDto getProductInfoById(final Long id) {
+	public ProductDetailResponseDto getProductById(final Long id) {
 		final Product product = productRepository.findById(id)
 			.orElseThrow(ProductNotFoundException::new);
 		return ProductDetailResponseDto.from(product);

--- a/src/main/java/taco/klkl/domain/product/service/ProductService.java
+++ b/src/main/java/taco/klkl/domain/product/service/ProductService.java
@@ -2,6 +2,7 @@ package taco.klkl.domain.product.service;
 
 import java.util.List;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,8 +25,8 @@ public class ProductService {
 	private final ProductRepository productRepository;
 	private final UserUtil userUtil;
 
-	public List<ProductSimpleResponseDto> getAllProducts() {
-		return productRepository.findAll().stream()
+	public List<ProductSimpleResponseDto> getAllProducts(Pageable pageable) {
+		return productRepository.findAll(pageable).stream()
 			.map(ProductSimpleResponseDto::from)
 			.toList();
 	}

--- a/src/main/java/taco/klkl/global/common/constants/ProductConstants.java
+++ b/src/main/java/taco/klkl/global/common/constants/ProductConstants.java
@@ -22,6 +22,16 @@ public final class ProductConstants {
 		2L,
 		3L
 	);
+	public static final Product TEST_PRODUCT_TWO = Product.of(
+		UserConstants.TEST_USER,
+		"testProductTwo",
+		"testDescriptionTwo",
+		"testAddressTwo",
+		2000,
+		2L,
+		4L,
+		6L
+	);
 
 	private ProductConstants() {
 	}

--- a/src/main/java/taco/klkl/global/common/constants/ProductConstants.java
+++ b/src/main/java/taco/klkl/global/common/constants/ProductConstants.java
@@ -4,6 +4,9 @@ import taco.klkl.domain.product.domain.Product;
 
 public final class ProductConstants {
 
+	public static final String DEFAULT_PAGE_NUMBER = "0";
+	public static final String DEFAULT_PAGE_SIZE = "9";
+
 	public static final int DEFAULT_PRICE = 0;
 	public static final int DEFAULT_LIKE_COUNT = 0;
 	public static final String DEFAULT_ADDRESS = "N/A";

--- a/src/test/java/taco/klkl/domain/product/controller/ProductControllerTest.java
+++ b/src/test/java/taco/klkl/domain/product/controller/ProductControllerTest.java
@@ -237,7 +237,10 @@ class ProductControllerTest {
 		mockMvc.perform(delete("/v1/products/{id}", productId)
 				.contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isNoContent())
-			.andExpect(jsonPath("$").doesNotExist());
+			.andExpect(jsonPath("$.isSuccess", is(true)))
+			.andExpect(jsonPath("$.code", is("C000")))
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.timestamp", notNullValue()));
 
 		verify(productService, times(1)).deleteProduct(productId);
 	}

--- a/src/test/java/taco/klkl/domain/product/controller/ProductControllerTest.java
+++ b/src/test/java/taco/klkl/domain/product/controller/ProductControllerTest.java
@@ -69,9 +69,9 @@ class ProductControllerTest {
 
 	@Test
 	@DisplayName("상품 상세 조회 API 테스트")
-	public void testGetProductInfoById() throws Exception {
+	public void testGetProductById() throws Exception {
 		// given
-		when(productService.getProductInfoById(1L)).thenReturn(productDetailResponseDto);
+		when(productService.getProductById(1L)).thenReturn(productDetailResponseDto);
 
 		// when & then
 		mockMvc.perform(get("/v1/products/1")

--- a/src/test/java/taco/klkl/domain/product/controller/ProductControllerTest.java
+++ b/src/test/java/taco/klkl/domain/product/controller/ProductControllerTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -30,22 +31,22 @@ import taco.klkl.domain.product.dto.response.ProductSimpleResponseDto;
 import taco.klkl.domain.product.exception.ProductNotFoundException;
 import taco.klkl.domain.product.service.ProductService;
 import taco.klkl.domain.user.domain.User;
+import taco.klkl.global.common.constants.ProductConstants;
 import taco.klkl.global.error.exception.ErrorCode;
 
 @WebMvcTest(ProductController.class)
 class ProductControllerTest {
 
 	@Autowired
-	MockMvc mockMvc;
+	private MockMvc mockMvc;
 
 	@MockBean
-	ProductService productService;
+	private ProductService productService;
 
 	@Autowired
 	ObjectMapper objectMapper;
 
 	private ProductDetailResponseDto productDetailDto;
-	private ProductSimpleResponseDto productSimpleDto;
 
 	@BeforeEach
 	public void setUp() {
@@ -69,62 +70,65 @@ class ProductControllerTest {
 
 		// ProductResponseDto 생성
 		productDetailDto = ProductDetailResponseDto.from(mockProduct);
-		productSimpleDto = ProductSimpleResponseDto.from(mockProduct);
 	}
 
 	@Test
-	@DisplayName("상품 목록 조회 API 테스트")
-	void testGetAllProducts() throws Exception {
+	@DisplayName("기본 페이징 값으로 상품 목록 API 조회 테스트")
+	void testGetAllProductsWithDefaultPaging() throws Exception {
 		// Given
-		List<ProductSimpleResponseDto> productList = Arrays.asList(productSimpleDto, productSimpleDto);
+		ProductSimpleResponseDto product1 = ProductSimpleResponseDto.from(ProductConstants.TEST_PRODUCT);
+		ProductSimpleResponseDto product2 = ProductSimpleResponseDto.from(ProductConstants.TEST_PRODUCT_TWO);
+		List<ProductSimpleResponseDto> productDtos = Arrays.asList(product1, product2);
 
-		when(productService.getAllProducts()).thenReturn(productList);
+		when(productService.getAllProducts(any(Pageable.class))).thenReturn(productDtos);
 
 		// When & Then
 		mockMvc.perform(get("/v1/products")
 				.contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.isSuccess", is(true)))
-			.andExpect(jsonPath("$.code", is("C000")))
 			.andExpect(jsonPath("$.data", hasSize(2)))
-			.andExpect(jsonPath("$.data[0].productId", is(productSimpleDto.productId().intValue())))
-			.andExpect(jsonPath("$.data[0].name", is(productSimpleDto.name())))
-			.andExpect(jsonPath("$.data[0].likeCount", is(productSimpleDto.likeCount())))
-			.andExpect(jsonPath("$.data[0].cityId", is(productSimpleDto.cityId().intValue())))
-			.andExpect(jsonPath("$.data[0].subcategoryId", is(productSimpleDto.subcategoryId().intValue())))
-			.andExpect(jsonPath("$.data[1].productId", is(productSimpleDto.productId().intValue())))
-			.andExpect(jsonPath("$.data[1].name", is(productSimpleDto.name())))
-			.andExpect(jsonPath("$.data[1].likeCount", is(productSimpleDto.likeCount())))
-			.andExpect(jsonPath("$.data[1].cityId", is(productSimpleDto.cityId().intValue())))
-			.andExpect(jsonPath("$.data[1].subcategoryId", is(productSimpleDto.subcategoryId().intValue())));
+			.andExpect(jsonPath("$.data[0].productId").value(product1.productId()))
+			.andExpect(jsonPath("$.data[1].productId").value(product2.productId()));
 
-		verify(productService, times(1)).getAllProducts();
+		verify(productService).getAllProducts(argThat(pageable ->
+			pageable.getPageNumber() == Integer.parseInt(ProductConstants.DEFAULT_PAGE_NUMBER)
+				&& pageable.getPageSize() == Integer.parseInt(ProductConstants.DEFAULT_PAGE_SIZE)
+		));
 	}
 
 	@Test
-	@DisplayName("빈 상품 목록 조회 API 테스트")
-	void testGetAllProductsEmptyList() throws Exception {
+	@DisplayName("사용자 지정 페이징 값으로 상품 목록 API 조회 테스트")
+	void testGetAllProductsWithCustomPaging() throws Exception {
 		// Given
-		when(productService.getAllProducts()).thenReturn(List.of());
+		ProductSimpleResponseDto product1 = ProductSimpleResponseDto.from(ProductConstants.TEST_PRODUCT);
+		ProductSimpleResponseDto product2 = ProductSimpleResponseDto.from(ProductConstants.TEST_PRODUCT_TWO);
+		List<ProductSimpleResponseDto> productDtos = Arrays.asList(product1, product2);
+
+		when(productService.getAllProducts(any(Pageable.class))).thenReturn(productDtos);
 
 		// When & Then
 		mockMvc.perform(get("/v1/products")
+				.param("page", "1")
+				.param("size", "5")
 				.contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.isSuccess", is(true)))
-			.andExpect(jsonPath("$.code", is("C000")))
-			.andExpect(jsonPath("$.data", hasSize(0)));
+			.andExpect(jsonPath("$.data", hasSize(2)))
+			.andExpect(jsonPath("$.data[0].productId").value(product1.productId()))
+			.andExpect(jsonPath("$.data[1].productId").value(product2.productId()));
 
-		verify(productService, times(1)).getAllProducts();
+		verify(productService).getAllProducts(argThat(pageable ->
+			pageable.getPageNumber() == 1
+				&& pageable.getPageSize() == 5
+		));
 	}
 
 	@Test
 	@DisplayName("상품 상세 조회 API 테스트")
-	public void testGetProductById() throws Exception {
-		// given
+	void testGetProductById() throws Exception {
+		// Given
 		when(productService.getProductById(1L)).thenReturn(productDetailDto);
 
-		// when & then
+		// When & Then
 		mockMvc.perform(get("/v1/products/1")
 				.contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
@@ -141,6 +145,8 @@ class ProductControllerTest {
 			.andExpect(jsonPath("$.data.subcategoryId", is(productDetailDto.subcategoryId().intValue())))
 			.andExpect(jsonPath("$.data.currencyId", is(productDetailDto.currencyId().intValue())))
 			.andExpect(jsonPath("$.timestamp", notNullValue()));
+
+		verify(productService).getProductById(1L);
 	}
 
 	@Test
@@ -176,37 +182,12 @@ class ProductControllerTest {
 			.andExpect(jsonPath("$.data.subcategoryId", is(productDetailDto.subcategoryId().intValue())))
 			.andExpect(jsonPath("$.data.currencyId", is(productDetailDto.currencyId().intValue())))
 			.andExpect(jsonPath("$.timestamp", notNullValue()));
+
+		verify(productService).createProduct(any(ProductCreateRequestDto.class));
 	}
 
 	@Test
-	@DisplayName("상품 등록 API 유효성 검사 실패 테스트")
-	public void testCreateProductValidationFailure() throws Exception {
-		// given
-		ProductCreateRequestDto invalidRequestDto = new ProductCreateRequestDto(
-			null,
-			null,
-			null,
-			null,
-			null,
-			null,
-			null
-		);
-
-		// when & then
-		ErrorCode methodArgumentInvalidError = ErrorCode.METHOD_ARGUMENT_INVALID;
-		mockMvc.perform(post("/v1/products")
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(objectMapper.writeValueAsString(invalidRequestDto)))
-			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.isSuccess", is(false)))
-			.andExpect(jsonPath("$.code", is(methodArgumentInvalidError.getCode())))
-			.andExpect(jsonPath("$.data.code", is(methodArgumentInvalidError.getCode())))
-			.andExpect(jsonPath("$.data.message", containsString(methodArgumentInvalidError.getMessage())))
-			.andExpect(jsonPath("$.timestamp", notNullValue()));
-	}
-
-	@Test
-	@DisplayName("상품 정보 부분 업데이트 API 테스트")
+	@DisplayName("상품 정보 수정 API 테스트")
 	public void testUpdateProduct() throws Exception {
 		// given
 		Long productId = 1L;
@@ -241,6 +222,8 @@ class ProductControllerTest {
 			.andExpect(jsonPath("$.data.subcategoryId", is(productDetailDto.subcategoryId().intValue())))
 			.andExpect(jsonPath("$.data.currencyId", is(productDetailDto.currencyId().intValue())))
 			.andExpect(jsonPath("$.timestamp", notNullValue()));
+
+		verify(productService).updateProduct(eq(productId), any(ProductUpdateRequestDto.class));
 	}
 
 	@Test
@@ -254,10 +237,7 @@ class ProductControllerTest {
 		mockMvc.perform(delete("/v1/products/{id}", productId)
 				.contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isNoContent())
-			.andExpect(jsonPath("$.isSuccess", is(true)))
-			.andExpect(jsonPath("$.code", is("C000")))
-			.andExpect(jsonPath("$.data").doesNotExist())
-			.andExpect(jsonPath("$.timestamp", notNullValue()));
+			.andExpect(jsonPath("$").doesNotExist());
 
 		verify(productService, times(1)).deleteProduct(productId);
 	}

--- a/src/test/java/taco/klkl/domain/product/controller/ProductControllerTest.java
+++ b/src/test/java/taco/klkl/domain/product/controller/ProductControllerTest.java
@@ -8,6 +8,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -24,6 +26,7 @@ import taco.klkl.domain.product.domain.Product;
 import taco.klkl.domain.product.dto.request.ProductCreateRequestDto;
 import taco.klkl.domain.product.dto.request.ProductUpdateRequestDto;
 import taco.klkl.domain.product.dto.response.ProductDetailResponseDto;
+import taco.klkl.domain.product.dto.response.ProductSimpleResponseDto;
 import taco.klkl.domain.product.exception.ProductNotFoundException;
 import taco.klkl.domain.product.service.ProductService;
 import taco.klkl.domain.user.domain.User;
@@ -41,7 +44,8 @@ class ProductControllerTest {
 	@Autowired
 	ObjectMapper objectMapper;
 
-	private ProductDetailResponseDto productDetailResponseDto;
+	private ProductDetailResponseDto productDetailDto;
+	private ProductSimpleResponseDto productSimpleDto;
 
 	@BeforeEach
 	public void setUp() {
@@ -63,15 +67,62 @@ class ProductControllerTest {
 		when(mockProduct.getSubcategoryId()).thenReturn(3L);
 		when(mockProduct.getCurrencyId()).thenReturn(4L);
 
-		// ProductDetailResponseDto 생성
-		productDetailResponseDto = ProductDetailResponseDto.from(mockProduct);
+		// ProductResponseDto 생성
+		productDetailDto = ProductDetailResponseDto.from(mockProduct);
+		productSimpleDto = ProductSimpleResponseDto.from(mockProduct);
+	}
+
+	@Test
+	@DisplayName("상품 목록 조회 API 테스트")
+	void testGetAllProducts() throws Exception {
+		// Given
+		List<ProductSimpleResponseDto> productList = Arrays.asList(productSimpleDto, productSimpleDto);
+
+		when(productService.getAllProducts()).thenReturn(productList);
+
+		// When & Then
+		mockMvc.perform(get("/v1/products")
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.isSuccess", is(true)))
+			.andExpect(jsonPath("$.code", is("C000")))
+			.andExpect(jsonPath("$.data", hasSize(2)))
+			.andExpect(jsonPath("$.data[0].productId", is(productSimpleDto.productId().intValue())))
+			.andExpect(jsonPath("$.data[0].name", is(productSimpleDto.name())))
+			.andExpect(jsonPath("$.data[0].likeCount", is(productSimpleDto.likeCount())))
+			.andExpect(jsonPath("$.data[0].cityId", is(productSimpleDto.cityId().intValue())))
+			.andExpect(jsonPath("$.data[0].subcategoryId", is(productSimpleDto.subcategoryId().intValue())))
+			.andExpect(jsonPath("$.data[1].productId", is(productSimpleDto.productId().intValue())))
+			.andExpect(jsonPath("$.data[1].name", is(productSimpleDto.name())))
+			.andExpect(jsonPath("$.data[1].likeCount", is(productSimpleDto.likeCount())))
+			.andExpect(jsonPath("$.data[1].cityId", is(productSimpleDto.cityId().intValue())))
+			.andExpect(jsonPath("$.data[1].subcategoryId", is(productSimpleDto.subcategoryId().intValue())));
+
+		verify(productService, times(1)).getAllProducts();
+	}
+
+	@Test
+	@DisplayName("빈 상품 목록 조회 API 테스트")
+	void testGetAllProductsEmptyList() throws Exception {
+		// Given
+		when(productService.getAllProducts()).thenReturn(List.of());
+
+		// When & Then
+		mockMvc.perform(get("/v1/products")
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.isSuccess", is(true)))
+			.andExpect(jsonPath("$.code", is("C000")))
+			.andExpect(jsonPath("$.data", hasSize(0)));
+
+		verify(productService, times(1)).getAllProducts();
 	}
 
 	@Test
 	@DisplayName("상품 상세 조회 API 테스트")
 	public void testGetProductById() throws Exception {
 		// given
-		when(productService.getProductById(1L)).thenReturn(productDetailResponseDto);
+		when(productService.getProductById(1L)).thenReturn(productDetailDto);
 
 		// when & then
 		mockMvc.perform(get("/v1/products/1")
@@ -79,16 +130,16 @@ class ProductControllerTest {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.isSuccess", is(true)))
 			.andExpect(jsonPath("$.code", is("C000")))
-			.andExpect(jsonPath("$.data.productId", is(productDetailResponseDto.productId().intValue())))
-			.andExpect(jsonPath("$.data.userId", is(productDetailResponseDto.userId().intValue())))
-			.andExpect(jsonPath("$.data.name", is(productDetailResponseDto.name())))
-			.andExpect(jsonPath("$.data.description", is(productDetailResponseDto.description())))
-			.andExpect(jsonPath("$.data.address", is(productDetailResponseDto.address())))
-			.andExpect(jsonPath("$.data.likeCount", is(productDetailResponseDto.likeCount())))
-			.andExpect(jsonPath("$.data.price", is(productDetailResponseDto.price())))
-			.andExpect(jsonPath("$.data.cityId", is(productDetailResponseDto.cityId().intValue())))
-			.andExpect(jsonPath("$.data.subcategoryId", is(productDetailResponseDto.subcategoryId().intValue())))
-			.andExpect(jsonPath("$.data.currencyId", is(productDetailResponseDto.currencyId().intValue())))
+			.andExpect(jsonPath("$.data.productId", is(productDetailDto.productId().intValue())))
+			.andExpect(jsonPath("$.data.userId", is(productDetailDto.userId().intValue())))
+			.andExpect(jsonPath("$.data.name", is(productDetailDto.name())))
+			.andExpect(jsonPath("$.data.description", is(productDetailDto.description())))
+			.andExpect(jsonPath("$.data.address", is(productDetailDto.address())))
+			.andExpect(jsonPath("$.data.likeCount", is(productDetailDto.likeCount())))
+			.andExpect(jsonPath("$.data.price", is(productDetailDto.price())))
+			.andExpect(jsonPath("$.data.cityId", is(productDetailDto.cityId().intValue())))
+			.andExpect(jsonPath("$.data.subcategoryId", is(productDetailDto.subcategoryId().intValue())))
+			.andExpect(jsonPath("$.data.currencyId", is(productDetailDto.currencyId().intValue())))
 			.andExpect(jsonPath("$.timestamp", notNullValue()));
 	}
 
@@ -105,7 +156,7 @@ class ProductControllerTest {
 			3L,
 			4L
 		);
-		when(productService.createProduct(any(ProductCreateRequestDto.class))).thenReturn(productDetailResponseDto);
+		when(productService.createProduct(any(ProductCreateRequestDto.class))).thenReturn(productDetailDto);
 
 		// when & then
 		mockMvc.perform(post("/v1/products")
@@ -114,16 +165,16 @@ class ProductControllerTest {
 			.andExpect(status().isCreated())
 			.andExpect(jsonPath("$.isSuccess", is(true)))
 			.andExpect(jsonPath("$.code", is("C000")))
-			.andExpect(jsonPath("$.data.productId", is(productDetailResponseDto.productId().intValue())))
-			.andExpect(jsonPath("$.data.userId", is(productDetailResponseDto.userId().intValue())))
-			.andExpect(jsonPath("$.data.name", is(productDetailResponseDto.name())))
-			.andExpect(jsonPath("$.data.description", is(productDetailResponseDto.description())))
-			.andExpect(jsonPath("$.data.address", is(productDetailResponseDto.address())))
-			.andExpect(jsonPath("$.data.likeCount", is(productDetailResponseDto.likeCount())))
-			.andExpect(jsonPath("$.data.price", is(productDetailResponseDto.price())))
-			.andExpect(jsonPath("$.data.cityId", is(productDetailResponseDto.cityId().intValue())))
-			.andExpect(jsonPath("$.data.subcategoryId", is(productDetailResponseDto.subcategoryId().intValue())))
-			.andExpect(jsonPath("$.data.currencyId", is(productDetailResponseDto.currencyId().intValue())))
+			.andExpect(jsonPath("$.data.productId", is(productDetailDto.productId().intValue())))
+			.andExpect(jsonPath("$.data.userId", is(productDetailDto.userId().intValue())))
+			.andExpect(jsonPath("$.data.name", is(productDetailDto.name())))
+			.andExpect(jsonPath("$.data.description", is(productDetailDto.description())))
+			.andExpect(jsonPath("$.data.address", is(productDetailDto.address())))
+			.andExpect(jsonPath("$.data.likeCount", is(productDetailDto.likeCount())))
+			.andExpect(jsonPath("$.data.price", is(productDetailDto.price())))
+			.andExpect(jsonPath("$.data.cityId", is(productDetailDto.cityId().intValue())))
+			.andExpect(jsonPath("$.data.subcategoryId", is(productDetailDto.subcategoryId().intValue())))
+			.andExpect(jsonPath("$.data.currencyId", is(productDetailDto.currencyId().intValue())))
 			.andExpect(jsonPath("$.timestamp", notNullValue()));
 	}
 
@@ -170,7 +221,7 @@ class ProductControllerTest {
 		);
 
 		when(productService.updateProduct(eq(productId), any(ProductUpdateRequestDto.class)))
-			.thenReturn(productDetailResponseDto);
+			.thenReturn(productDetailDto);
 
 		// when & then
 		mockMvc.perform(patch("/v1/products/{id}", productId)
@@ -179,16 +230,16 @@ class ProductControllerTest {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.isSuccess", is(true)))
 			.andExpect(jsonPath("$.code", is("C000")))
-			.andExpect(jsonPath("$.data.productId", is(productDetailResponseDto.productId().intValue())))
-			.andExpect(jsonPath("$.data.userId", is(productDetailResponseDto.userId().intValue())))
-			.andExpect(jsonPath("$.data.name", is(productDetailResponseDto.name())))
-			.andExpect(jsonPath("$.data.description", is(productDetailResponseDto.description())))
-			.andExpect(jsonPath("$.data.address", is(productDetailResponseDto.address())))
-			.andExpect(jsonPath("$.data.likeCount", is(productDetailResponseDto.likeCount())))
-			.andExpect(jsonPath("$.data.price", is(productDetailResponseDto.price())))
-			.andExpect(jsonPath("$.data.cityId", is(productDetailResponseDto.cityId().intValue())))
-			.andExpect(jsonPath("$.data.subcategoryId", is(productDetailResponseDto.subcategoryId().intValue())))
-			.andExpect(jsonPath("$.data.currencyId", is(productDetailResponseDto.currencyId().intValue())))
+			.andExpect(jsonPath("$.data.productId", is(productDetailDto.productId().intValue())))
+			.andExpect(jsonPath("$.data.userId", is(productDetailDto.userId().intValue())))
+			.andExpect(jsonPath("$.data.name", is(productDetailDto.name())))
+			.andExpect(jsonPath("$.data.description", is(productDetailDto.description())))
+			.andExpect(jsonPath("$.data.address", is(productDetailDto.address())))
+			.andExpect(jsonPath("$.data.likeCount", is(productDetailDto.likeCount())))
+			.andExpect(jsonPath("$.data.price", is(productDetailDto.price())))
+			.andExpect(jsonPath("$.data.cityId", is(productDetailDto.cityId().intValue())))
+			.andExpect(jsonPath("$.data.subcategoryId", is(productDetailDto.subcategoryId().intValue())))
+			.andExpect(jsonPath("$.data.currencyId", is(productDetailDto.currencyId().intValue())))
 			.andExpect(jsonPath("$.timestamp", notNullValue()));
 	}
 

--- a/src/test/java/taco/klkl/domain/product/service/ProductServiceTest.java
+++ b/src/test/java/taco/klkl/domain/product/service/ProductServiceTest.java
@@ -43,7 +43,7 @@ class ProductServiceTest {
 
 	@Test
 	@DisplayName("ID로 상품 정보를 조회할 때, 상품이 존재하면 ProductDetailResponseDto를 반환해야 한다.")
-	void testGetProductInfoById_Success() {
+	void testGetProductById_Success() {
 		// given
 		Long productId = 1L;
 
@@ -51,7 +51,7 @@ class ProductServiceTest {
 		when(productRepository.findById(productId)).thenReturn(Optional.of(product));
 
 		// when
-		ProductDetailResponseDto responseDto = productService.getProductInfoById(productId);
+		ProductDetailResponseDto responseDto = productService.getProductById(productId);
 
 		// then
 		assertThat(responseDto).isNotNull();
@@ -70,14 +70,14 @@ class ProductServiceTest {
 
 	@Test
 	@DisplayName("ID로 상품 정보를 조회할 때, 상품이 존재하지 않으면 ProductNotFoundException을 발생시켜야 한다.")
-	void testGetProductInfoById_NotFound() {
+	void testGetProductById_NotFound() {
 		// given
 		Long productId = 1L;
 		when(productRepository.findById(productId)).thenReturn(Optional.empty());
 
 		// when & then
 		ProductNotFoundException exception = assertThrows(ProductNotFoundException.class, () -> {
-			productService.getProductInfoById(productId);
+			productService.getProductById(productId);
 		});
 
 		// 예외가 발생했는지 확인

--- a/src/test/java/taco/klkl/domain/product/service/ProductServiceTest.java
+++ b/src/test/java/taco/klkl/domain/product/service/ProductServiceTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -18,6 +20,7 @@ import taco.klkl.domain.product.domain.Product;
 import taco.klkl.domain.product.dto.request.ProductCreateRequestDto;
 import taco.klkl.domain.product.dto.request.ProductUpdateRequestDto;
 import taco.klkl.domain.product.dto.response.ProductDetailResponseDto;
+import taco.klkl.domain.product.dto.response.ProductSimpleResponseDto;
 import taco.klkl.domain.product.exception.ProductNotFoundException;
 import taco.klkl.domain.user.domain.User;
 import taco.klkl.global.common.constants.ProductConstants;
@@ -39,6 +42,72 @@ class ProductServiceTest {
 	void setUp() {
 		MockitoAnnotations.openMocks(this);
 		user = new User();
+	}
+
+	@Test
+	@DisplayName("모든 상품 조회 테스트")
+	void testGetAllProducts() {
+		// Given
+		Product product1 = ProductConstants.TEST_PRODUCT;
+		Product product2 = ProductConstants.TEST_PRODUCT_TWO;
+		List<Product> productList = Arrays.asList(product1, product2);
+
+		when(productRepository.findAll()).thenReturn(productList);
+
+		// When
+		List<ProductSimpleResponseDto> result = productService.getAllProducts();
+
+		// Then
+		assertThat(result).hasSize(2);
+
+		assertThat(result.get(0))
+			.extracting(
+				ProductSimpleResponseDto::productId,
+				ProductSimpleResponseDto::name,
+				ProductSimpleResponseDto::likeCount,
+				ProductSimpleResponseDto::cityId,
+				ProductSimpleResponseDto::subcategoryId
+			)
+			.containsExactly(
+				product1.getProductId(),
+				product1.getName(),
+				product1.getLikeCount(),
+				product1.getCityId(),
+				product1.getSubcategoryId()
+			);
+
+		assertThat(result.get(1))
+			.extracting(
+				ProductSimpleResponseDto::productId,
+				ProductSimpleResponseDto::name,
+				ProductSimpleResponseDto::likeCount,
+				ProductSimpleResponseDto::cityId,
+				ProductSimpleResponseDto::subcategoryId
+			)
+			.containsExactly(
+				product2.getProductId(),
+				product2.getName(),
+				product2.getLikeCount(),
+				product2.getCityId(),
+				product2.getSubcategoryId()
+			);
+
+		verify(productRepository, times(1)).findAll();
+	}
+
+	@Test
+	@DisplayName("빈 상품 목록 조회 테스트")
+	void testGetAllProductsEmptyList() {
+		// Given
+		when(productRepository.findAll()).thenReturn(List.of());
+
+		// When
+		List<ProductSimpleResponseDto> result = productService.getAllProducts();
+
+		// Then
+		assertNotNull(result);
+		assertTrue(result.isEmpty());
+		verify(productRepository, times(1)).findAll();
 	}
 
 	@Test


### PR DESCRIPTION
## 📌 연관된 이슈
- **[KL-125/전체 상품 목록 조회](https://ohhamma.atlassian.net/browse/KL-125)**

## 📝 작업 내용
- 모든 상품 목록 조회 API 구현
- 페이지네이션 적용
- 불필요한 Entity 키워드 제거

## 🌳 작업 브랜치명
- `KL-125/전체-상품-목록-조회`

## 📸 스크린샷 (선택)

## 💬 리뷰 요구사항 (선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced paginated retrieval for product listings.
  - Simplified response handling for product creation, updates, and deletions.

- **Bug Fixes**
  - Renamed methods for consistency in the product retrieval process.

- **Tests**
  - Expanded test coverage for product retrieval and pagination scenarios.
  - Updated test method names to align with recent changes in the product service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->