### PR TITLE
feat(KL-89): filter Product by countryIds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
 //	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -33,6 +34,9 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
+	annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 //	testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/taco/klkl/domain/product/controller/ProductController.java
+++ b/src/main/java/taco/klkl/domain/product/controller/ProductController.java
@@ -44,7 +44,7 @@ public class ProductController {
 		@RequestParam(name = "country_id", required = false) List<Long> countryIds
 	) {
 		ProductFilterOptionsDto filterOptions = new ProductFilterOptionsDto(countryIds);
-		return productService.getProductsByFilterOptions(filterOptions, pageable);
+		return productService.getProductsByFilterOptions(pageable, filterOptions);
 	}
 
 	@GetMapping("/{id}")

--- a/src/main/java/taco/klkl/domain/product/controller/ProductController.java
+++ b/src/main/java/taco/klkl/domain/product/controller/ProductController.java
@@ -1,9 +1,7 @@
 package taco.klkl.domain.product.controller;
 
-import java.util.List;
-
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -13,7 +11,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,6 +19,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import taco.klkl.domain.product.dto.request.ProductCreateUpdateRequestDto;
+import taco.klkl.domain.product.dto.response.PagedResponseDto;
 import taco.klkl.domain.product.dto.response.ProductDetailResponseDto;
 import taco.klkl.domain.product.dto.response.ProductSimpleResponseDto;
 import taco.klkl.domain.product.service.ProductService;
@@ -37,12 +35,10 @@ public class ProductController {
 
 	@GetMapping
 	@Operation(summary = "상품 목록 조회", description = "상품 목록을 조회합니다.")
-	public List<ProductSimpleResponseDto> getAllProducts(
-		@RequestParam(defaultValue = ProductConstants.DEFAULT_PAGE_NUMBER) int page,
-		@RequestParam(defaultValue = ProductConstants.DEFAULT_PAGE_SIZE) int size
+	public PagedResponseDto<ProductSimpleResponseDto> getProducts(
+		@PageableDefault(size = ProductConstants.DEFAULT_PAGE_SIZE) Pageable pageable
 	) {
-		Pageable pageable = PageRequest.of(page, size);
-		return productService.getAllProducts(pageable);
+		return productService.getProducts(pageable);
 	}
 
 	@GetMapping("/{id}")

--- a/src/main/java/taco/klkl/domain/product/controller/ProductController.java
+++ b/src/main/java/taco/klkl/domain/product/controller/ProductController.java
@@ -1,5 +1,7 @@
 package taco.klkl.domain.product.controller;
 
+import java.util.List;
+
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
@@ -11,6 +13,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,6 +22,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import taco.klkl.domain.product.dto.request.ProductCreateUpdateRequestDto;
+import taco.klkl.domain.product.dto.request.ProductFilterOptionsDto;
 import taco.klkl.domain.product.dto.response.PagedResponseDto;
 import taco.klkl.domain.product.dto.response.ProductDetailResponseDto;
 import taco.klkl.domain.product.dto.response.ProductSimpleResponseDto;
@@ -36,9 +40,11 @@ public class ProductController {
 	@GetMapping
 	@Operation(summary = "상품 목록 조회", description = "상품 목록을 조회합니다.")
 	public PagedResponseDto<ProductSimpleResponseDto> getProducts(
-		@PageableDefault(size = ProductConstants.DEFAULT_PAGE_SIZE) Pageable pageable
+		@PageableDefault(size = ProductConstants.DEFAULT_PAGE_SIZE) Pageable pageable,
+		@RequestParam(name = "country_id", required = false) List<Long> countryIds
 	) {
-		return productService.getProducts(pageable);
+		ProductFilterOptionsDto filterOptions = new ProductFilterOptionsDto(countryIds);
+		return productService.getProductsByFilterOptions(filterOptions, pageable);
 	}
 
 	@GetMapping("/{id}")

--- a/src/main/java/taco/klkl/domain/product/domain/Product.java
+++ b/src/main/java/taco/klkl/domain/product/domain/Product.java
@@ -7,6 +7,7 @@ import org.hibernate.annotations.DynamicInsert;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -70,28 +71,40 @@ public class Product {
 	@ColumnDefault(DefaultConstants.DEFAULT_INT_STRING)
 	private Integer likeCount;
 
-	@ManyToOne(optional = false)
+	@ManyToOne(
+		fetch = FetchType.LAZY,
+		optional = false
+	)
 	@JoinColumn(
 		name = "user_id",
 		nullable = false
 	)
 	private User user;
 
-	@ManyToOne(optional = false)
+	@ManyToOne(
+		fetch = FetchType.LAZY,
+		optional = false
+	)
 	@JoinColumn(
 		name = "city_id",
 		nullable = false
 	)
 	private City city;
 
-	@ManyToOne(optional = false)
+	@ManyToOne(
+		fetch = FetchType.LAZY,
+		optional = false
+	)
 	@JoinColumn(
 		name = "subcategory_id",
 		nullable = false
 	)
 	private Subcategory subcategory;
 
-	@ManyToOne(optional = false)
+	@ManyToOne(
+		fetch = FetchType.LAZY,
+		optional = false
+	)
 	@JoinColumn(
 		name = "currency_id",
 		nullable = false

--- a/src/main/java/taco/klkl/domain/product/dto/request/ProductFilterOptionsDto.java
+++ b/src/main/java/taco/klkl/domain/product/dto/request/ProductFilterOptionsDto.java
@@ -1,0 +1,8 @@
+package taco.klkl.domain.product.dto.request;
+
+import java.util.List;
+
+public record ProductFilterOptionsDto(
+	List<Long> countryIds
+) {
+}

--- a/src/main/java/taco/klkl/domain/product/dto/response/PagedResponseDto.java
+++ b/src/main/java/taco/klkl/domain/product/dto/response/PagedResponseDto.java
@@ -1,0 +1,31 @@
+package taco.klkl.domain.product.dto.response;
+
+import java.util.List;
+import java.util.function.Function;
+
+import org.springframework.data.domain.Page;
+
+public record PagedResponseDto<T>(
+	List<T> content,
+	int pageNumber,
+	int pageSize,
+	long totalElements,
+	int totalPages,
+	boolean last
+) {
+
+	public static <T, R> PagedResponseDto<R> of(Page<T> page, Function<T, R> mapper) {
+		List<R> content = page.getContent().stream()
+			.map(mapper)
+			.toList();
+
+		return new PagedResponseDto<>(
+			content,
+			page.getNumber(),
+			page.getSize(),
+			page.getTotalElements(),
+			page.getTotalPages(),
+			page.isLast()
+		);
+	}
+}

--- a/src/main/java/taco/klkl/domain/product/dto/response/ProductSimpleResponseDto.java
+++ b/src/main/java/taco/klkl/domain/product/dto/response/ProductSimpleResponseDto.java
@@ -8,15 +8,15 @@ import taco.klkl.domain.product.domain.Product;
  * @param productId
  * @param name
  * @param likeCount
- * @param cityId
- * @param subcategoryId
+ * @param countryName
+ * @param categoryName
  */
 public record ProductSimpleResponseDto(
 	Long productId,
 	String name,
 	int likeCount,
-	Long cityId,
-	Long subcategoryId
+	String countryName,
+	String categoryName
 ) {
 
 	public static ProductSimpleResponseDto from(Product product) {
@@ -24,8 +24,8 @@ public record ProductSimpleResponseDto(
 			product.getId(),
 			product.getName(),
 			product.getLikeCount(),
-			product.getCity().getCityId(),
-			product.getSubcategory().getId()
+			product.getCity().getCountry().getName().getKoreanName(),
+			product.getSubcategory().getCategory().getName().getKoreanName()
 		);
 	}
 }

--- a/src/main/java/taco/klkl/domain/product/service/ProductService.java
+++ b/src/main/java/taco/klkl/domain/product/service/ProductService.java
@@ -1,7 +1,6 @@
 package taco.klkl.domain.product.service;
 
-import java.util.List;
-
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,6 +12,7 @@ import taco.klkl.domain.category.service.SubcategoryService;
 import taco.klkl.domain.product.dao.ProductRepository;
 import taco.klkl.domain.product.domain.Product;
 import taco.klkl.domain.product.dto.request.ProductCreateUpdateRequestDto;
+import taco.klkl.domain.product.dto.response.PagedResponseDto;
 import taco.klkl.domain.product.dto.response.ProductDetailResponseDto;
 import taco.klkl.domain.product.dto.response.ProductSimpleResponseDto;
 import taco.klkl.domain.product.exception.ProductNotFoundException;
@@ -38,10 +38,9 @@ public class ProductService {
 
 	private final UserUtil userUtil;
 
-	public List<ProductSimpleResponseDto> getAllProducts(Pageable pageable) {
-		return productRepository.findAll(pageable).stream()
-			.map(ProductSimpleResponseDto::from)
-			.toList();
+	public PagedResponseDto<ProductSimpleResponseDto> getProducts(Pageable pageable) {
+		Page<Product> productPage = productRepository.findAll(pageable);
+		return PagedResponseDto.of(productPage, ProductSimpleResponseDto::from);
 	}
 
 	public ProductDetailResponseDto getProductById(final Long id) throws ProductNotFoundException {

--- a/src/main/java/taco/klkl/domain/product/service/ProductService.java
+++ b/src/main/java/taco/klkl/domain/product/service/ProductService.java
@@ -48,8 +48,8 @@ public class ProductService {
 	private final UserUtil userUtil;
 
 	public PagedResponseDto<ProductSimpleResponseDto> getProductsByFilterOptions(
-		ProductFilterOptionsDto fiilterOptions,
-		Pageable pageable
+		Pageable pageable,
+		ProductFilterOptionsDto fiilterOptions
 	) {
 		QProduct product = QProduct.product;
 		BooleanBuilder builder = buildFilterOptions(fiilterOptions, product);

--- a/src/main/java/taco/klkl/domain/product/service/ProductService.java
+++ b/src/main/java/taco/klkl/domain/product/service/ProductService.java
@@ -1,9 +1,15 @@
 package taco.klkl.domain.product.service;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
 import taco.klkl.domain.category.domain.Subcategory;
@@ -11,7 +17,9 @@ import taco.klkl.domain.category.exception.SubcategoryNotFoundException;
 import taco.klkl.domain.category.service.SubcategoryService;
 import taco.klkl.domain.product.dao.ProductRepository;
 import taco.klkl.domain.product.domain.Product;
+import taco.klkl.domain.product.domain.QProduct;
 import taco.klkl.domain.product.dto.request.ProductCreateUpdateRequestDto;
+import taco.klkl.domain.product.dto.request.ProductFilterOptionsDto;
 import taco.klkl.domain.product.dto.response.PagedResponseDto;
 import taco.klkl.domain.product.dto.response.ProductDetailResponseDto;
 import taco.klkl.domain.product.dto.response.ProductSimpleResponseDto;
@@ -30,6 +38,7 @@ import taco.klkl.global.util.UserUtil;
 @RequiredArgsConstructor
 public class ProductService {
 
+	private final JPAQueryFactory queryFactory;
 	private final ProductRepository productRepository;
 
 	private final CityService cityService;
@@ -38,8 +47,25 @@ public class ProductService {
 
 	private final UserUtil userUtil;
 
-	public PagedResponseDto<ProductSimpleResponseDto> getProducts(Pageable pageable) {
-		Page<Product> productPage = productRepository.findAll(pageable);
+	public PagedResponseDto<ProductSimpleResponseDto> getProductsByFilterOptions(
+		ProductFilterOptionsDto fiilterOptions,
+		Pageable pageable
+	) {
+		QProduct product = QProduct.product;
+		BooleanBuilder builder = buildFilterOptions(fiilterOptions, product);
+
+		List<Product> products = queryFactory.selectFrom(product)
+			.where(builder)
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+
+		long total = queryFactory.select(product.count())
+			.from(product)
+			.where(builder)
+			.fetchOne();
+
+		Page<Product> productPage = new PageImpl<>(products, pageable, total);
 		return PagedResponseDto.of(productPage, ProductSimpleResponseDto::from);
 	}
 
@@ -70,6 +96,16 @@ public class ProductService {
 		final Product product = productRepository.findById(id)
 			.orElseThrow(ProductNotFoundException::new);
 		productRepository.delete(product);
+	}
+
+	private BooleanBuilder buildFilterOptions(ProductFilterOptionsDto options, QProduct product) {
+		BooleanBuilder builder = new BooleanBuilder();
+
+		if (options.countryIds() != null && !options.countryIds().isEmpty()) {
+			builder.and(product.city.country.countryId.in(options.countryIds()));
+		}
+
+		return builder;
 	}
 
 	private Product createProductEntity(final ProductCreateUpdateRequestDto createRequest) {

--- a/src/main/java/taco/klkl/domain/product/service/ProductService.java
+++ b/src/main/java/taco/klkl/domain/product/service/ProductService.java
@@ -49,10 +49,10 @@ public class ProductService {
 
 	public PagedResponseDto<ProductSimpleResponseDto> getProductsByFilterOptions(
 		Pageable pageable,
-		ProductFilterOptionsDto fiilterOptions
+		ProductFilterOptionsDto filterOptions
 	) {
 		QProduct product = QProduct.product;
-		BooleanBuilder builder = buildFilterOptions(fiilterOptions, product);
+		BooleanBuilder builder = buildFilterOptions(filterOptions, product);
 
 		List<Product> products = queryFactory.selectFrom(product)
 			.where(builder)

--- a/src/main/java/taco/klkl/global/common/constants/ProductConstants.java
+++ b/src/main/java/taco/klkl/global/common/constants/ProductConstants.java
@@ -2,8 +2,7 @@ package taco.klkl.global.common.constants;
 
 public final class ProductConstants {
 
-	public static final String DEFAULT_PAGE_NUMBER = "0";
-	public static final String DEFAULT_PAGE_SIZE = "9";
+	public static final int DEFAULT_PAGE_SIZE = 9;
 
 	public static final int DEFAULT_PRICE = 0;
 	public static final int DEFAULT_LIKE_COUNT = 0;

--- a/src/main/java/taco/klkl/global/config/querydsl/QueryDslConfig.java
+++ b/src/main/java/taco/klkl/global/config/querydsl/QueryDslConfig.java
@@ -1,0 +1,21 @@
+package taco.klkl.global.config.querydsl;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+@Configuration
+public class QueryDslConfig {
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		return new JPAQueryFactory(entityManager);
+	}
+}

--- a/src/test/java/taco/klkl/domain/product/controller/ProductControllerTest.java
+++ b/src/test/java/taco/klkl/domain/product/controller/ProductControllerTest.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import taco.klkl.domain.category.domain.CategoryName;
 import taco.klkl.domain.category.dto.response.SubcategoryResponseDto;
 import taco.klkl.domain.product.dto.request.ProductCreateUpdateRequestDto;
+import taco.klkl.domain.product.dto.request.ProductFilterOptionsDto;
 import taco.klkl.domain.product.dto.response.PagedResponseDto;
 import taco.klkl.domain.product.dto.response.ProductDetailResponseDto;
 import taco.klkl.domain.product.dto.response.ProductSimpleResponseDto;
@@ -113,12 +114,14 @@ public class ProductControllerTest {
 		PagedResponseDto<ProductSimpleResponseDto> pagedResponse = new PagedResponseDto<>(
 			products, 0, 10, 1, 1, true
 		);
-		when(productService.getProducts(any(Pageable.class))).thenReturn(pagedResponse);
+		when(productService.getProductsByFilterOptions(any(ProductFilterOptionsDto.class), any(Pageable.class)))
+			.thenReturn(pagedResponse);
 
 		// When & Then
 		mockMvc.perform(get("/v1/products")
 				.param("page", "0")
-				.param("size", "10"))
+				.param("size", "10")
+				.param("countryIds", "1", "2", "3")) // Add countryIds as query parameters
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.isSuccess", is(true)))
 			.andExpect(jsonPath("$.code", is("C000")))

--- a/src/test/java/taco/klkl/domain/product/controller/ProductControllerTest.java
+++ b/src/test/java/taco/klkl/domain/product/controller/ProductControllerTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import taco.klkl.domain.category.dto.response.SubcategoryResponseDto;
 import taco.klkl.domain.product.dto.request.ProductCreateUpdateRequestDto;
+import taco.klkl.domain.product.dto.response.PagedResponseDto;
 import taco.klkl.domain.product.dto.response.ProductDetailResponseDto;
 import taco.klkl.domain.product.dto.response.ProductSimpleResponseDto;
 import taco.klkl.domain.product.service.ProductService;
@@ -104,10 +105,13 @@ public class ProductControllerTest {
 
 	@Test
 	@DisplayName("상품 목록 조회 - 성공")
-	void testGetAllProducts_ShouldReturnListOfProducts() throws Exception {
+	void testGetProducts_ShouldReturnPagedProducts() throws Exception {
 		// Given
 		List<ProductSimpleResponseDto> products = Arrays.asList(productSimpleResponseDto);
-		when(productService.getAllProducts(any(PageRequest.class))).thenReturn(products);
+		PagedResponseDto<ProductSimpleResponseDto> pagedResponse = new PagedResponseDto<>(
+			products, 0, 10, 1, 1, true
+		);
+		when(productService.getProducts(any(Pageable.class))).thenReturn(pagedResponse);
 
 		// When & Then
 		mockMvc.perform(get("/v1/products")
@@ -116,13 +120,20 @@ public class ProductControllerTest {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.isSuccess", is(true)))
 			.andExpect(jsonPath("$.code", is("C000")))
-			.andExpect(jsonPath("$.data", hasSize(1)))
-			.andExpect(jsonPath("$.data[0].productId", is(productSimpleResponseDto.productId().intValue())))
-			.andExpect(jsonPath("$.data[0].name", is(productSimpleResponseDto.name())))
-			.andExpect(jsonPath("$.data[0].likeCount", is(productSimpleResponseDto.likeCount())))
-			.andExpect(jsonPath("$.data[0].cityId", is(productSimpleResponseDto.cityId().intValue())))
-			.andExpect(jsonPath("$.data[0].subcategoryId",
+			.andExpect(jsonPath("$.data.content", hasSize(1)))
+			.andExpect(jsonPath("$.data.content[0].productId",
+				is(productSimpleResponseDto.productId().intValue())))
+			.andExpect(jsonPath("$.data.content[0].name", is(productSimpleResponseDto.name())))
+			.andExpect(jsonPath("$.data.content[0].likeCount", is(productSimpleResponseDto.likeCount())))
+			.andExpect(jsonPath("$.data.content[0].cityId",
+				is(productSimpleResponseDto.cityId().intValue())))
+			.andExpect(jsonPath("$.data.content[0].subcategoryId",
 				is(productSimpleResponseDto.subcategoryId().intValue())))
+			.andExpect(jsonPath("$.data.pageNumber", is(0)))
+			.andExpect(jsonPath("$.data.pageSize", is(10)))
+			.andExpect(jsonPath("$.data.totalElements", is(1)))
+			.andExpect(jsonPath("$.data.totalPages", is(1)))
+			.andExpect(jsonPath("$.data.last", is(true)))
 			.andExpect(jsonPath("$.timestamp", notNullValue()));
 	}
 

--- a/src/test/java/taco/klkl/domain/product/controller/ProductControllerTest.java
+++ b/src/test/java/taco/klkl/domain/product/controller/ProductControllerTest.java
@@ -114,7 +114,7 @@ public class ProductControllerTest {
 		PagedResponseDto<ProductSimpleResponseDto> pagedResponse = new PagedResponseDto<>(
 			products, 0, 10, 1, 1, true
 		);
-		when(productService.getProductsByFilterOptions(any(ProductFilterOptionsDto.class), any(Pageable.class)))
+		when(productService.getProductsByFilterOptions(any(Pageable.class), any(ProductFilterOptionsDto.class)))
 			.thenReturn(pagedResponse);
 
 		// When & Then

--- a/src/test/java/taco/klkl/domain/product/controller/ProductControllerTest.java
+++ b/src/test/java/taco/klkl/domain/product/controller/ProductControllerTest.java
@@ -23,6 +23,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import taco.klkl.domain.category.domain.CategoryName;
 import taco.klkl.domain.category.dto.response.SubcategoryResponseDto;
 import taco.klkl.domain.product.dto.request.ProductCreateUpdateRequestDto;
 import taco.klkl.domain.product.dto.response.PagedResponseDto;
@@ -31,6 +32,7 @@ import taco.klkl.domain.product.dto.response.ProductSimpleResponseDto;
 import taco.klkl.domain.product.service.ProductService;
 import taco.klkl.domain.region.dto.response.CityResponseDto;
 import taco.klkl.domain.region.dto.response.CurrencyResponseDto;
+import taco.klkl.domain.region.enums.CountryType;
 import taco.klkl.domain.user.dto.response.UserDetailResponseDto;
 
 @WebMvcTest(ProductController.class)
@@ -76,8 +78,8 @@ public class ProductControllerTest {
 			1L,
 			"productName",
 			10,
-			1L,
-			1L
+			CountryType.THAILAND.getKoreanName(),
+			CategoryName.FOOD.getKoreanName()
 		);
 		productDetailResponseDto = new ProductDetailResponseDto(
 			1L,
@@ -125,10 +127,9 @@ public class ProductControllerTest {
 				is(productSimpleResponseDto.productId().intValue())))
 			.andExpect(jsonPath("$.data.content[0].name", is(productSimpleResponseDto.name())))
 			.andExpect(jsonPath("$.data.content[0].likeCount", is(productSimpleResponseDto.likeCount())))
-			.andExpect(jsonPath("$.data.content[0].cityId",
-				is(productSimpleResponseDto.cityId().intValue())))
-			.andExpect(jsonPath("$.data.content[0].subcategoryId",
-				is(productSimpleResponseDto.subcategoryId().intValue())))
+			.andExpect(jsonPath("$.data.content[0].countryName", is(productSimpleResponseDto.countryName())))
+			.andExpect(jsonPath("$.data.content[0].categoryName",
+				is(productSimpleResponseDto.categoryName())))
 			.andExpect(jsonPath("$.data.pageNumber", is(0)))
 			.andExpect(jsonPath("$.data.pageSize", is(10)))
 			.andExpect(jsonPath("$.data.totalElements", is(1)))

--- a/src/test/java/taco/klkl/domain/product/dto/response/ProductSimpleResponseDtoTest.java
+++ b/src/test/java/taco/klkl/domain/product/dto/response/ProductSimpleResponseDtoTest.java
@@ -3,66 +3,109 @@ package taco.klkl.domain.product.dto.response;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
 
+import taco.klkl.domain.category.domain.Category;
+import taco.klkl.domain.category.domain.CategoryName;
 import taco.klkl.domain.category.domain.Subcategory;
+import taco.klkl.domain.category.domain.SubcategoryName;
 import taco.klkl.domain.product.domain.Product;
 import taco.klkl.domain.region.domain.City;
+import taco.klkl.domain.region.domain.Country;
+import taco.klkl.domain.region.domain.Currency;
+import taco.klkl.domain.region.domain.Region;
+import taco.klkl.domain.region.enums.CityType;
+import taco.klkl.domain.region.enums.CountryType;
+import taco.klkl.domain.region.enums.CurrencyType;
+import taco.klkl.domain.region.enums.RegionType;
+import taco.klkl.domain.user.domain.User;
 
 class ProductSimpleResponseDtoTest {
+
+	private Product product;
+	private User mockUser;
+	private City city;
+	private Subcategory subcategory;
+	private Currency currency;
+
+	@BeforeEach
+	void setUp() {
+		MockitoAnnotations.openMocks(this);
+
+		mockUser = mock(User.class);
+		when(mockUser.getId()).thenReturn(1L);
+		when(mockUser.getName()).thenReturn("Test User");
+
+		Region region = Region.of(RegionType.SOUTHEAST_ASIA);
+		currency = Currency.of(
+			CurrencyType.THAI_BAHT,
+			"image/baht.jpg"
+		);
+		Country country = Country.of(
+			CountryType.JAPAN,
+			region,
+			"image/thailand-flag.jpg",
+			"image/thailand-photo.jpg",
+			currency
+		);
+		city = City.of(
+			country,
+			CityType.BANGKOK
+		);
+
+		Category category = Category.of(CategoryName.FOOD);
+		subcategory = Subcategory.of(
+			category,
+			SubcategoryName.INSTANT_FOOD
+		);
+
+		product = mock(Product.class);
+		when(product.getId()).thenReturn(1L);
+		when(product.getName()).thenReturn("productName");
+		when(product.getDescription()).thenReturn("productDescription");
+		when(product.getAddress()).thenReturn("productAddress");
+		when(product.getPrice()).thenReturn(1000);
+		when(product.getLikeCount()).thenReturn(0);
+		when(product.getUser()).thenReturn(mockUser);
+		when(product.getCity()).thenReturn(city);
+		when(product.getSubcategory()).thenReturn(subcategory);
+		when(product.getCurrency()).thenReturn(currency);
+	}
+
 	@Test
 	@DisplayName("Product 객체로부터 ProductSimpleResponseDto 생성 테스트")
 	void testFromProduct() {
-		// given
-		Long productId = 1L;
-		String name = "맛있는 곤약젤리";
-		int likeCount = 10;
-		City mockCity = mock(City.class);
-		Subcategory mockSubcategory = mock(Subcategory.class);
-
-		Product mockProduct = mock(Product.class);
-		when(mockProduct.getId()).thenReturn(productId);
-		when(mockProduct.getName()).thenReturn(name);
-		when(mockProduct.getLikeCount()).thenReturn(likeCount);
-		when(mockProduct.getCity()).thenReturn(mockCity);
-		when(mockProduct.getSubcategory()).thenReturn(mockSubcategory);
-
 		// when
-		ProductSimpleResponseDto dto = ProductSimpleResponseDto.from(mockProduct);
+		ProductSimpleResponseDto dto = ProductSimpleResponseDto.from(product);
 
 		// then
-		assertThat(dto.productId()).isEqualTo(productId);
-		assertThat(dto.name()).isEqualTo(name);
-		assertThat(dto.likeCount()).isEqualTo(likeCount);
-		assertThat(dto.cityId()).isEqualTo(mockCity.getCityId());
-		assertThat(dto.subcategoryId()).isEqualTo(mockSubcategory.getId());
+		assertThat(dto.productId()).isEqualTo(product.getId());
+		assertThat(dto.name()).isEqualTo(product.getName());
+		assertThat(dto.likeCount()).isEqualTo(product.getLikeCount());
+		assertThat(dto.countryName()).isEqualTo(product.getCity().getCountry().getName().getKoreanName());
+		assertThat(dto.categoryName()).isEqualTo(product.getSubcategory().getCategory().getName().getKoreanName());
 	}
 
 	@Test
 	@DisplayName("생성자를 통해 ProductSimpleResponseDto 생성 테스트")
 	void testConstructor() {
-		// given
-		Long productId = 1L;
-		String name = "맛있는 곤약젤리";
-		int likeCount = 10;
-		City mockCity = mock(City.class);
-		Subcategory mockSubcategory = mock(Subcategory.class);
-
 		// when
 		ProductSimpleResponseDto dto = new ProductSimpleResponseDto(
-			productId,
-			name,
-			likeCount,
-			mockCity.getCityId(),
-			mockSubcategory.getId()
+			product.getId(),
+			product.getName(),
+			product.getLikeCount(),
+			city.getCountry().getName().getKoreanName(),
+			product.getSubcategory().getCategory().getName().getKoreanName()
 		);
 
 		// then
-		assertThat(dto.productId()).isEqualTo(productId);
-		assertThat(dto.name()).isEqualTo(name);
-		assertThat(dto.likeCount()).isEqualTo(likeCount);
-		assertThat(dto.cityId()).isEqualTo(mockCity.getCityId());
-		assertThat(dto.subcategoryId()).isEqualTo(mockSubcategory.getId());
+		assertThat(dto.productId()).isEqualTo(product.getId());
+		assertThat(dto.name()).isEqualTo(product.getName());
+		assertThat(dto.likeCount()).isEqualTo(product.getLikeCount());
+		assertThat(dto.countryName()).isEqualTo(city.getCountry().getName().getKoreanName());
+		assertThat(dto.categoryName()).isEqualTo(product.getSubcategory().getCategory().getName().getKoreanName());
 	}
 }

--- a/src/test/java/taco/klkl/domain/product/integration/ProductIntegrationTest.java
+++ b/src/test/java/taco/klkl/domain/product/integration/ProductIntegrationTest.java
@@ -133,13 +133,20 @@ public class ProductIntegrationTest {
 
 		// when & then
 		mockMvc.perform(get("/v1/products")
+				.param("page", "0")
+				.param("size", "10")
 				.contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.isSuccess", is(true)))
 			.andExpect(jsonPath("$.code", is("C000")))
-			.andExpect(jsonPath("$.data", hasSize(3)))
-			.andExpect(jsonPath("$.data[0].name", is(createRequest1.name())))
-			.andExpect(jsonPath("$.data[1].name", is(createRequest2.name())))
+			.andExpect(jsonPath("$.data.content", hasSize(3)))
+			.andExpect(jsonPath("$.data.content[0].name", is(createRequest1.name())))
+			.andExpect(jsonPath("$.data.content[1].name", is(createRequest2.name())))
+			.andExpect(jsonPath("$.data.pageNumber", is(0)))
+			.andExpect(jsonPath("$.data.pageSize", is(10)))
+			.andExpect(jsonPath("$.data.totalElements", is(3)))
+			.andExpect(jsonPath("$.data.totalPages", is(1)))
+			.andExpect(jsonPath("$.data.last", is(true)))
 			.andExpect(jsonPath("$.timestamp", notNullValue()));
 	}
 

--- a/src/test/java/taco/klkl/domain/product/service/ProductServiceTest.java
+++ b/src/test/java/taco/klkl/domain/product/service/ProductServiceTest.java
@@ -26,6 +26,7 @@ import taco.klkl.domain.category.service.SubcategoryService;
 import taco.klkl.domain.product.dao.ProductRepository;
 import taco.klkl.domain.product.domain.Product;
 import taco.klkl.domain.product.dto.request.ProductCreateUpdateRequestDto;
+import taco.klkl.domain.product.dto.response.PagedResponseDto;
 import taco.klkl.domain.product.dto.response.ProductDetailResponseDto;
 import taco.klkl.domain.product.dto.response.ProductSimpleResponseDto;
 import taco.klkl.domain.product.exception.ProductNotFoundException;
@@ -111,18 +112,24 @@ class ProductServiceTest {
 
 	@Test
 	@DisplayName("상품 목록 조회 - 성공")
-	void testGetAllProducts() {
+	void testGetProducts() {
 		// Given
 		Pageable pageable = PageRequest.of(0, 10);
-		Page<Product> productPage = new PageImpl<>(Arrays.asList(mockProduct));
+		List<Product> productList = Arrays.asList(mockProduct);
+		Page<Product> productPage = new PageImpl<>(productList, pageable, productList.size());
 		when(productRepository.findAll(pageable)).thenReturn(productPage);
 
 		// When
-		List<ProductSimpleResponseDto> result = productService.getAllProducts(pageable);
+		PagedResponseDto<ProductSimpleResponseDto> result = productService.getProducts(pageable);
 
 		// Then
-		assertThat(result).hasSize(1);
-		assertThat(result.get(0).productId()).isEqualTo(mockProduct.getId());
+		assertThat(result.content()).hasSize(1);
+		assertThat(result.content().get(0).productId()).isEqualTo(mockProduct.getId());
+		assertThat(result.totalElements()).isEqualTo(1);
+		assertThat(result.totalPages()).isEqualTo(1);
+		assertThat(result.pageNumber()).isEqualTo(0);
+		assertThat(result.pageSize()).isEqualTo(10);
+		assertThat(result.last()).isTrue();
 		verify(productRepository).findAll(pageable);
 	}
 

--- a/src/test/java/taco/klkl/domain/product/service/ProductServiceTest.java
+++ b/src/test/java/taco/klkl/domain/product/service/ProductServiceTest.java
@@ -162,7 +162,7 @@ class ProductServiceTest {
 
 		// When
 		PagedResponseDto<ProductSimpleResponseDto> result = productService
-			.getProductsByFilterOptions(filterOptions, pageable);
+			.getProductsByFilterOptions(pageable, filterOptions);
 
 		// Then
 		assertThat(result.content()).hasSize(1);


### PR DESCRIPTION
## 📌 연관된 이슈
- **[KL-89/국가별 필터링](https://ohhamma.atlassian.net/browse/KL-89)**

## 📝 작업 내용
- 페이지네이션 로직 적용
- 상품 목록 조회 api 변경
  - 프론트에서 요구한 필드 추가
- QueryDSL 설정 추가
- 다중 국가 ID로 상품 필터링

## 🌳 작업 브랜치명
- `KL-89/국가별-필터링`

## 📸 스크린샷 (선택)

## 💬 리뷰 요구사항 (선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced product filtering capabilities based on country IDs.
  - Added pagination support for product retrieval.

- **Documentation**
  - Updated test cases and documentation to reflect new method names and functionalities.

- **Refactor**
  - Streamlined product listing methods and improved data handling structure.

- **Tests**
  - Expanded test coverage for product retrieval and filtering functionalities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->