### PR TITLE
feat(KL-140): add product search

### DIFF
--- a/src/main/java/taco/klkl/domain/product/service/ProductService.java
+++ b/src/main/java/taco/klkl/domain/product/service/ProductService.java
@@ -12,6 +12,8 @@ import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
+import taco.klkl.domain.category.domain.QCategory;
+import taco.klkl.domain.category.domain.QSubcategory;
 import taco.klkl.domain.category.domain.Subcategory;
 import taco.klkl.domain.category.exception.SubcategoryNotFoundException;
 import taco.klkl.domain.category.service.SubcategoryService;
@@ -26,6 +28,8 @@ import taco.klkl.domain.product.exception.InvalidCityIdsException;
 import taco.klkl.domain.product.exception.ProductNotFoundException;
 import taco.klkl.domain.region.domain.City;
 import taco.klkl.domain.region.domain.Currency;
+import taco.klkl.domain.region.domain.QCity;
+import taco.klkl.domain.region.domain.QCountry;
 import taco.klkl.domain.region.exception.CityNotFoundException;
 import taco.klkl.domain.region.exception.CountryNotFoundException;
 import taco.klkl.domain.region.exception.CurrencyNotFoundException;
@@ -111,6 +115,28 @@ public class ProductService {
 
 	public boolean existsProductById(final Long id) {
 		return productRepository.existsById(id);
+	}
+
+	public List<ProductSimpleResponseDto> getProductsByPartialName(String partialName) {
+
+		QProduct product = QProduct.product;
+		QCity city = QCity.city;
+		QCountry country = QCountry.country;
+		QSubcategory subcategory = QSubcategory.subcategory;
+		QCategory category = QCategory.category;
+
+		List<Product> products = queryFactory
+			.selectFrom(product)
+			.join(product.city, city).fetchJoin()
+			.join(city.country, country).fetchJoin()
+			.join(product.subcategory, subcategory).fetchJoin()
+			.join(subcategory.category, category).fetchJoin()
+			.where(product.name.contains(partialName))
+			.fetch();
+
+		return products.stream()
+			.map(ProductSimpleResponseDto::from)
+			.toList();
 	}
 
 	private BooleanBuilder buildFilterOptions(ProductFilterOptionsDto options, QProduct product) {

--- a/src/main/java/taco/klkl/domain/search/dto/response/SearchResponseDto.java
+++ b/src/main/java/taco/klkl/domain/search/dto/response/SearchResponseDto.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import taco.klkl.domain.category.dto.response.CategoryResponseDto;
 import taco.klkl.domain.category.dto.response.SubcategoryResponseDto;
+import taco.klkl.domain.product.dto.response.ProductSimpleResponseDto;
 import taco.klkl.domain.region.dto.response.CityResponseDto;
 import taco.klkl.domain.region.dto.response.CountrySimpleResponseDto;
 
@@ -11,14 +12,16 @@ public record SearchResponseDto(
 	List<CountrySimpleResponseDto> countries,
 	List<CityResponseDto> cities,
 	List<CategoryResponseDto> categories,
-	List<SubcategoryResponseDto> subcategories
+	List<SubcategoryResponseDto> subcategories,
+	List<ProductSimpleResponseDto> products
 ) {
 	public static SearchResponseDto of(
 		List<CountrySimpleResponseDto> countries,
 		List<CityResponseDto> cities,
 		List<CategoryResponseDto> categories,
-		List<SubcategoryResponseDto> subcategories
+		List<SubcategoryResponseDto> subcategories,
+		List<ProductSimpleResponseDto> products
 	) {
-		return new SearchResponseDto(countries, cities, categories, subcategories);
+		return new SearchResponseDto(countries, cities, categories, subcategories, products);
 	}
 }

--- a/src/main/java/taco/klkl/domain/search/service/SearchServiceImpl.java
+++ b/src/main/java/taco/klkl/domain/search/service/SearchServiceImpl.java
@@ -14,6 +14,8 @@ import taco.klkl.domain.category.dto.response.CategoryResponseDto;
 import taco.klkl.domain.category.dto.response.SubcategoryResponseDto;
 import taco.klkl.domain.category.service.CategoryService;
 import taco.klkl.domain.category.service.SubcategoryService;
+import taco.klkl.domain.product.dto.response.ProductSimpleResponseDto;
+import taco.klkl.domain.product.service.ProductService;
 import taco.klkl.domain.region.dto.response.CityResponseDto;
 import taco.klkl.domain.region.dto.response.CountrySimpleResponseDto;
 import taco.klkl.domain.region.enums.CityType;
@@ -33,6 +35,7 @@ public class SearchServiceImpl implements SearchService {
 	private final CityService cityService;
 	private final CategoryService categoryService;
 	private final SubcategoryService subcategoryService;
+	private final ProductService productService;
 
 	@Override
 	public SearchResponseDto getSearchResult(final String queryParam) {
@@ -41,8 +44,9 @@ public class SearchServiceImpl implements SearchService {
 		final List<CityResponseDto> findCities = getCitiesByQueryParam(queryParam);
 		final List<CategoryResponseDto> findCategories = getCategoriesByQueryParam(queryParam);
 		final List<SubcategoryResponseDto> findSubcategories = getSubcategoriesByQueryParam(queryParam);
+		List<ProductSimpleResponseDto> findProducts = getProductsByQueryParam(queryParam);
 
-		return SearchResponseDto.of(findCountries, findCities, findCategories, findSubcategories);
+		return SearchResponseDto.of(findCountries, findCities, findCategories, findSubcategories, findProducts);
 	}
 
 	private List<CountrySimpleResponseDto> getCountriesByQueryParam(final String queryParam) {
@@ -67,6 +71,10 @@ public class SearchServiceImpl implements SearchService {
 		final List<SubcategoryName> subcategoryNames = SubcategoryName.getSubcategoryNamesByPartialString(queryParam);
 
 		return subcategoryService.getSubcategoriesBySubcategoryNames(subcategoryNames);
+	}
+
+	private List<ProductSimpleResponseDto> getProductsByQueryParam(final String queryParam) {
+		return productService.getProductsByPartialName(queryParam);
 	}
 
 }

--- a/src/test/java/taco/klkl/domain/product/service/ProductServiceTest.java
+++ b/src/test/java/taco/klkl/domain/product/service/ProductServiceTest.java
@@ -2,6 +2,7 @@ package taco.klkl.domain.product.service;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.Arrays;
@@ -25,6 +26,8 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import taco.klkl.domain.category.domain.Category;
 import taco.klkl.domain.category.domain.CategoryName;
+import taco.klkl.domain.category.domain.QCategory;
+import taco.klkl.domain.category.domain.QSubcategory;
 import taco.klkl.domain.category.domain.Subcategory;
 import taco.klkl.domain.category.domain.SubcategoryName;
 import taco.klkl.domain.category.service.SubcategoryService;
@@ -41,6 +44,8 @@ import taco.klkl.domain.product.exception.ProductNotFoundException;
 import taco.klkl.domain.region.domain.City;
 import taco.klkl.domain.region.domain.Country;
 import taco.klkl.domain.region.domain.Currency;
+import taco.klkl.domain.region.domain.QCity;
+import taco.klkl.domain.region.domain.QCountry;
 import taco.klkl.domain.region.domain.Region;
 import taco.klkl.domain.region.enums.CityType;
 import taco.klkl.domain.region.enums.CountryType;
@@ -362,6 +367,34 @@ class ProductServiceTest {
 		org.junit.jupiter.api.Assertions.assertThrows(LikeCountBelowMinimumException.class, () -> {
 			productService.decreaseLikeCount(mockProduct);
 		});
+	}
+
+	@Test
+	@DisplayName("상품이름 부분문자열 조회 테스트")
+	void testGetProductsByPartialName() {
+		// given
+		String partialName = "am";
+		List<Product> mockProducts = List.of(testProduct);
+
+		JPAQuery<Product> mockQuery = mock(JPAQuery.class);
+		when(queryFactory.selectFrom(QProduct.product)).thenReturn(mockQuery);
+		when(mockQuery.join(QProduct.product.city, QCity.city)).thenReturn(mockQuery);
+		when(mockQuery.fetchJoin()).thenReturn(mockQuery);
+		when(mockQuery.join(QCity.city.country, QCountry.country)).thenReturn(mockQuery);
+		when(mockQuery.fetchJoin()).thenReturn(mockQuery);
+		when(mockQuery.join(QProduct.product.subcategory, QSubcategory.subcategory)).thenReturn(mockQuery);
+		when(mockQuery.fetchJoin()).thenReturn(mockQuery);
+		when(mockQuery.join(QSubcategory.subcategory.category, QCategory.category)).thenReturn(mockQuery);
+		when(mockQuery.fetchJoin()).thenReturn(mockQuery);
+		when(mockQuery.where(QProduct.product.name.contains(partialName))).thenReturn(mockQuery);
+		when(mockQuery.fetch()).thenReturn(mockProducts);
+
+		// when
+		List<ProductSimpleResponseDto> responseDtos = productService.getProductsByPartialName(partialName);
+
+		// then
+		assertThat(responseDtos.get(0)).isEqualTo(ProductSimpleResponseDto.from(testProduct));
+
 	}
 
 }

--- a/src/test/java/taco/klkl/domain/search/controller/SearchControllerTest.java
+++ b/src/test/java/taco/klkl/domain/search/controller/SearchControllerTest.java
@@ -20,6 +20,8 @@ import taco.klkl.domain.category.domain.Subcategory;
 import taco.klkl.domain.category.domain.SubcategoryName;
 import taco.klkl.domain.category.dto.response.CategoryResponseDto;
 import taco.klkl.domain.category.dto.response.SubcategoryResponseDto;
+import taco.klkl.domain.product.domain.Product;
+import taco.klkl.domain.product.dto.response.ProductSimpleResponseDto;
 import taco.klkl.domain.region.domain.City;
 import taco.klkl.domain.region.domain.Country;
 import taco.klkl.domain.region.domain.Currency;
@@ -30,6 +32,8 @@ import taco.klkl.domain.region.enums.CityType;
 import taco.klkl.domain.region.enums.CountryType;
 import taco.klkl.domain.search.dto.response.SearchResponseDto;
 import taco.klkl.domain.search.service.SearchService;
+import taco.klkl.domain.user.domain.User;
+import taco.klkl.global.common.constants.UserConstants;
 
 @WebMvcTest(SearchController.class)
 public class SearchControllerTest {
@@ -48,10 +52,21 @@ public class SearchControllerTest {
 	@Mock
 	Currency currency;
 
+	private final User user = UserConstants.TEST_USER;
 	private final Country country = Country.of(CountryType.MALAYSIA, region, "flag", "photo", currency);
 	private final City city = City.of(country, CityType.BORACAY);
 	private final Category category = Category.of(CategoryName.CLOTHES);
 	private final Subcategory subcategory = Subcategory.of(category, SubcategoryName.MAKEUP);
+	private final Product product = Product.of(
+		"name",
+		"description",
+		"address",
+		1000,
+		user,
+		city,
+		subcategory,
+		currency
+	);
 
 	@BeforeEach
 	void setUp() {
@@ -60,7 +75,8 @@ public class SearchControllerTest {
 			Collections.singletonList(CountrySimpleResponseDto.from(country)),
 			Collections.singletonList(CityResponseDto.from(city)),
 			Collections.singletonList(CategoryResponseDto.from(category)),
-			Collections.singletonList(SubcategoryResponseDto.from(subcategory))
+			Collections.singletonList(SubcategoryResponseDto.from(subcategory)),
+			Collections.singletonList(ProductSimpleResponseDto.from(product))
 		);
 	}
 
@@ -78,6 +94,7 @@ public class SearchControllerTest {
 			.andExpect(jsonPath("$.data.countries").isArray())
 			.andExpect(jsonPath("$.data.cities").isArray())
 			.andExpect(jsonPath("$.data.categories").isArray())
-			.andExpect(jsonPath("$.data.subcategories").isArray());
+			.andExpect(jsonPath("$.data.subcategories").isArray())
+			.andExpect(jsonPath("$.data.products").isArray());
 	}
 }

--- a/src/test/java/taco/klkl/domain/search/integration/SearchIntegrationTest.java
+++ b/src/test/java/taco/klkl/domain/search/integration/SearchIntegrationTest.java
@@ -28,7 +28,7 @@ public class SearchIntegrationTest {
 	@Test
 	void getSearchTest() throws Exception {
 		// given
-		String query = "이";
+		String query = "리";
 		SearchResponseDto searchResponseDto = searchService.getSearchResult(query);
 
 		// when & then
@@ -40,6 +40,7 @@ public class SearchIntegrationTest {
 			.andExpect(jsonPath("$.data.countries", hasSize(searchResponseDto.countries().size())))
 			.andExpect(jsonPath("$.data.cities", hasSize(searchResponseDto.cities().size())))
 			.andExpect(jsonPath("$.data.categories", hasSize(searchResponseDto.categories().size())))
-			.andExpect(jsonPath("$.data.subcategories", hasSize(searchResponseDto.subcategories().size())));
+			.andExpect(jsonPath("$.data.subcategories", hasSize(searchResponseDto.subcategories().size())))
+			.andExpect(jsonPath("$.data.products", hasSize(searchResponseDto.products().size())));
 	}
 }

--- a/src/test/java/taco/klkl/domain/search/service/SearchServiceImplTest.java
+++ b/src/test/java/taco/klkl/domain/search/service/SearchServiceImplTest.java
@@ -21,6 +21,9 @@ import taco.klkl.domain.category.dto.response.CategoryResponseDto;
 import taco.klkl.domain.category.dto.response.SubcategoryResponseDto;
 import taco.klkl.domain.category.service.CategoryService;
 import taco.klkl.domain.category.service.SubcategoryService;
+import taco.klkl.domain.product.domain.Product;
+import taco.klkl.domain.product.dto.response.ProductSimpleResponseDto;
+import taco.klkl.domain.product.service.ProductService;
 import taco.klkl.domain.region.domain.City;
 import taco.klkl.domain.region.domain.Country;
 import taco.klkl.domain.region.domain.Currency;
@@ -32,6 +35,8 @@ import taco.klkl.domain.region.enums.CountryType;
 import taco.klkl.domain.region.service.CityService;
 import taco.klkl.domain.region.service.CountryService;
 import taco.klkl.domain.search.dto.response.SearchResponseDto;
+import taco.klkl.domain.user.domain.User;
+import taco.klkl.global.common.constants.UserConstants;
 
 @ExtendWith(MockitoExtension.class)
 class SearchServiceImplTest {
@@ -52,6 +57,9 @@ class SearchServiceImplTest {
 	SubcategoryService subcategoryService;
 
 	@Mock
+	ProductService productService;
+
+	@Mock
 	Region region;
 
 	@Mock
@@ -61,12 +69,23 @@ class SearchServiceImplTest {
 	private final City city = City.of(country, CityType.BORACAY);
 	private final Category category = Category.of(CategoryName.CLOTHES);
 	private final Subcategory subcategory = Subcategory.of(category, SubcategoryName.MAKEUP);
+	private final User user = UserConstants.TEST_USER;
+	private final Product product = Product.of(
+		"ProductTestProduct",
+		"description",
+		"address",
+		1000,
+		user,
+		city,
+		subcategory,
+		currency
+	);
 
 	@Test
 	@DisplayName("SearchService 테스트")
 	void testGetSearchResult() {
 		// given
-		String queryParam = "test";
+		String queryParam = "Test";
 
 		List<CountrySimpleResponseDto> mockCountries = Collections.singletonList(
 			CountrySimpleResponseDto.from(country));
@@ -74,11 +93,13 @@ class SearchServiceImplTest {
 		List<CategoryResponseDto> mockCategories = Collections.singletonList(CategoryResponseDto.from(category));
 		List<SubcategoryResponseDto> mockSubcategories = Collections.singletonList(
 			SubcategoryResponseDto.from(subcategory));
+		List<ProductSimpleResponseDto> mockProducts = Collections.singletonList(ProductSimpleResponseDto.from(product));
 
 		when(countryService.getAllCountriesByCountryTypes(any(List.class))).thenReturn(mockCountries);
 		when(cityService.getAllCitiesByCityTypes(any(List.class))).thenReturn(mockCities);
 		when(categoryService.getCategoriesByCategoryNames(any(List.class))).thenReturn(mockCategories);
 		when(subcategoryService.getSubcategoriesBySubcategoryNames(any(List.class))).thenReturn(mockSubcategories);
+		when(productService.getProductsByPartialName(queryParam)).thenReturn(mockProducts);
 
 		// when
 		SearchResponseDto result = searchService.getSearchResult(queryParam);
@@ -89,5 +110,6 @@ class SearchServiceImplTest {
 		assertThat(result.cities()).isEqualTo(mockCities);
 		assertThat(result.categories()).isEqualTo(mockCategories);
 		assertThat(result.subcategories()).isEqualTo(mockSubcategories);
+		assertThat(result.products()).isEqualTo(mockProducts);
 	}
 }


### PR DESCRIPTION
## 📌 연관된 이슈
[KL-140/상품이름 검색 기능 추가](https://ohhamma.atlassian.net/browse/KL-140)

## 📝 작업 내용
- 검색API에 상품이름으로 검색 추가

## 🌳 작업 브랜치명
KL-140/상품이름-검색기능-추가

## 📸 스크린샷 (선택)

## 💬 리뷰 요구사항 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added functionality to search for products using partial names.
	- Enhanced search results to include product details alongside existing categories and subcategories.

- **Bug Fixes**
	- Improved validation in search tests to ensure accurate product retrieval.

- **Tests**
	- Introduced new tests for verifying the product search functionality and ensuring the integrity of product data in search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->