### PR TITLE
feat(KL-131): add rating field to product

### DIFF
--- a/src/main/java/taco/klkl/domain/product/converter/RatingConverter.java
+++ b/src/main/java/taco/klkl/domain/product/converter/RatingConverter.java
@@ -22,6 +22,6 @@ public class RatingConverter implements AttributeConverter<Rating, BigDecimal> {
 		if (dbData == null) {
 			return null;
 		}
-		return Rating.valueOf(dbData.toString());
+		return Rating.from(dbData.doubleValue());
 	}
 }

--- a/src/main/java/taco/klkl/domain/product/converter/RatingConverter.java
+++ b/src/main/java/taco/klkl/domain/product/converter/RatingConverter.java
@@ -1,0 +1,27 @@
+package taco.klkl.domain.product.converter;
+
+import java.math.BigDecimal;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import taco.klkl.domain.product.domain.Rating;
+
+@Converter(autoApply = true)
+public class RatingConverter implements AttributeConverter<Rating, BigDecimal> {
+
+	@Override
+	public BigDecimal convertToDatabaseColumn(final Rating attribute) {
+		if (attribute == null) {
+			return null;
+		}
+		return BigDecimal.valueOf(attribute.getValue());
+	}
+
+	@Override
+	public Rating convertToEntityAttribute(final BigDecimal dbData) {
+		if (dbData == null) {
+			return null;
+		}
+		return Rating.valueOf(dbData.toString());
+	}
+}

--- a/src/main/java/taco/klkl/domain/product/domain/Product.java
+++ b/src/main/java/taco/klkl/domain/product/domain/Product.java
@@ -9,6 +9,7 @@ import org.hibernate.annotations.DynamicInsert;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -23,6 +24,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import taco.klkl.domain.category.domain.Filter;
 import taco.klkl.domain.category.domain.Subcategory;
+import taco.klkl.domain.product.converter.RatingConverter;
 import taco.klkl.domain.region.domain.City;
 import taco.klkl.domain.region.domain.Currency;
 import taco.klkl.domain.user.domain.User;
@@ -75,6 +77,15 @@ public class Product {
 	)
 	@ColumnDefault(DefaultConstants.DEFAULT_INT_STRING)
 	private Integer likeCount;
+
+	@Convert(converter = RatingConverter.class)
+	@Column(
+		name = "rating",
+		precision = 3,
+		scale = 1,
+		nullable = false
+	)
+	private Rating rating;
 
 	@ManyToOne(
 		fetch = FetchType.LAZY,
@@ -145,6 +156,7 @@ public class Product {
 		final String description,
 		final String address,
 		final Integer price,
+		final Rating rating,
 		final User user,
 		final City city,
 		final Subcategory subcategory,
@@ -154,6 +166,7 @@ public class Product {
 		this.description = description;
 		this.address = address;
 		this.price = price;
+		this.rating = rating;
 		this.user = user;
 		this.city = city;
 		this.subcategory = subcategory;
@@ -167,12 +180,13 @@ public class Product {
 		final String description,
 		final String address,
 		final Integer price,
+		final Rating rating,
 		final User user,
 		final City city,
 		final Subcategory subcategory,
 		final Currency currency
 	) {
-		return new Product(name, description, address, price, user, city, subcategory, currency);
+		return new Product(name, description, address, price, rating, user, city, subcategory, currency);
 	}
 
 	public void update(
@@ -180,6 +194,7 @@ public class Product {
 		final String description,
 		final String address,
 		final Integer price,
+		final Rating rating,
 		final City city,
 		final Subcategory subcategory,
 		final Currency currency
@@ -188,6 +203,7 @@ public class Product {
 		this.description = description;
 		this.address = address;
 		this.price = price;
+		this.rating = rating;
 		this.city = city;
 		this.subcategory = subcategory;
 		this.currency = currency;

--- a/src/main/java/taco/klkl/domain/product/domain/Rating.java
+++ b/src/main/java/taco/klkl/domain/product/domain/Rating.java
@@ -1,0 +1,34 @@
+package taco.klkl.domain.product.domain;
+
+import java.util.Arrays;
+
+import lombok.Getter;
+import taco.klkl.domain.product.exception.RatingNotFoundException;
+
+@Getter
+public enum Rating {
+	ZERO_FIVE(0.5),
+	ONE(1.0),
+	ONE_FIVE(1.5),
+	TWO(2.0),
+	TWO_FIVE(2.5),
+	THREE(3.0),
+	THREE_FIVE(3.5),
+	FOUR(4.0),
+	FOUR_FIVE(4.5),
+	FIVE(5.0),
+	;
+
+	private final double value;
+
+	Rating(double value) {
+		this.value = value;
+	}
+
+	public static Rating from(final double value) {
+		return Arrays.stream(Rating.values())
+			.filter(r -> r.value == value)
+			.findFirst()
+			.orElseThrow(RatingNotFoundException::new);
+	}
+}

--- a/src/main/java/taco/klkl/domain/product/dto/request/ProductCreateUpdateRequestDto.java
+++ b/src/main/java/taco/klkl/domain/product/dto/request/ProductCreateUpdateRequestDto.java
@@ -1,5 +1,8 @@
 package taco.klkl.domain.product.dto.request;
 
+import static taco.klkl.global.common.constants.ProductConstants.*;
+import static taco.klkl.global.common.constants.ProductValidationMessages.*;
+
 import java.util.Set;
 
 import jakarta.validation.constraints.DecimalMax;
@@ -9,9 +12,6 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
 import taco.klkl.global.common.constants.ProductConstants;
-
-import static taco.klkl.global.common.constants.ProductValidationMessages.*;
-import static taco.klkl.global.common.constants.ProductConstants.*;
 
 /**
  * TODO: 상품필터속성 추가 해야함 (상품필터속성 테이블 개발 후)

--- a/src/main/java/taco/klkl/domain/product/dto/request/ProductCreateUpdateRequestDto.java
+++ b/src/main/java/taco/klkl/domain/product/dto/request/ProductCreateUpdateRequestDto.java
@@ -2,12 +2,16 @@ package taco.klkl.domain.product.dto.request;
 
 import java.util.Set;
 
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
 import taco.klkl.global.common.constants.ProductConstants;
-import taco.klkl.global.common.constants.ProductValidationMessages;
+
+import static taco.klkl.global.common.constants.ProductValidationMessages.*;
+import static taco.klkl.global.common.constants.ProductConstants.*;
 
 /**
  * TODO: 상품필터속성 추가 해야함 (상품필터속성 테이블 개발 후)
@@ -21,31 +25,36 @@ import taco.klkl.global.common.constants.ProductValidationMessages;
  * @param currencyId
  */
 public record ProductCreateUpdateRequestDto(
-	@NotNull(message = ProductValidationMessages.NAME_NOT_NULL)
-	@NotBlank(message = ProductValidationMessages.NAME_NOT_BLANK)
-	@Size(max = ProductConstants.NAME_MAX_LENGTH, message = ProductValidationMessages.NAME_SIZE)
+	@NotNull(message = NAME_NOT_NULL)
+	@NotBlank(message = NAME_NOT_BLANK)
+	@Size(max = ProductConstants.NAME_MAX_LENGTH, message = NAME_SIZE)
 	String name,
 
-	@NotNull(message = ProductValidationMessages.DESCRIPTION_NOT_NULL)
-	@NotBlank(message = ProductValidationMessages.DESCRIPTION_NOT_BLANK)
-	@Size(max = ProductConstants.DESCRIPTION_MAX_LENGTH, message = ProductValidationMessages.DESCRIPTION_SIZE)
+	@NotNull(message = DESCRIPTION_NOT_NULL)
+	@NotBlank(message = DESCRIPTION_NOT_BLANK)
+	@Size(max = ProductConstants.DESCRIPTION_MAX_LENGTH, message = DESCRIPTION_SIZE)
 	String description,
 
-	@NotNull(message = ProductValidationMessages.ADDRESS_NOT_NULL)
-	@Size(max = ProductConstants.ADDRESS_MAX_LENGTH, message = ProductValidationMessages.ADDRESS_SIZE)
+	@NotNull(message = ADDRESS_NOT_NULL)
+	@Size(max = ProductConstants.ADDRESS_MAX_LENGTH, message = ADDRESS_SIZE)
 	String address,
 
-	@NotNull(message = ProductValidationMessages.PRICE_NOT_NULL)
-	@PositiveOrZero(message = ProductValidationMessages.PRICE_POSITIVE_OR_ZERO)
+	@NotNull(message = PRICE_NOT_NULL)
+	@PositiveOrZero(message = PRICE_POSITIVE_OR_ZERO)
 	Integer price,
 
-	@NotNull(message = ProductValidationMessages.CITY_ID_NOT_NULL)
+	@NotNull(message = RATING_NOT_NULL)
+	@DecimalMin(value = RATING_MIN_VALUE, message = RATING_UNDER_MIN)
+	@DecimalMax(value = RATING_MAX_VALUE, message = RATING_OVER_MAX)
+	Double rating,
+
+	@NotNull(message = CITY_ID_NOT_NULL)
 	Long cityId,
 
-	@NotNull(message = ProductValidationMessages.SUBCATEGORY_ID_NOT_NULL)
+	@NotNull(message = SUBCATEGORY_ID_NOT_NULL)
 	Long subcategoryId,
 
-	@NotNull(message = ProductValidationMessages.CURRENCY_ID_NOT_NULL)
+	@NotNull(message = CURRENCY_ID_NOT_NULL)
 	Long currencyId,
 
 	Set<Long> filterIds

--- a/src/main/java/taco/klkl/domain/product/dto/response/ProductDetailResponseDto.java
+++ b/src/main/java/taco/klkl/domain/product/dto/response/ProductDetailResponseDto.java
@@ -24,6 +24,7 @@ import taco.klkl.domain.user.dto.response.UserDetailResponseDto;
  * @param address
  * @param price
  * @param likeCount
+ * @param rating
  * @param user
  * @param city
  * @param subcategory
@@ -35,8 +36,9 @@ public record ProductDetailResponseDto(
 	String name,
 	String description,
 	String address,
-	int price,
-	int likeCount,
+	Integer price,
+	Integer likeCount,
+	Double rating,
 	UserDetailResponseDto user,
 	CityResponseDto city,
 	SubcategoryResponseDto subcategory,
@@ -61,6 +63,7 @@ public record ProductDetailResponseDto(
 			product.getAddress(),
 			product.getPrice(),
 			product.getLikeCount(),
+			product.getRating().getValue(),
 			UserDetailResponseDto.from(product.getUser()),
 			CityResponseDto.from(product.getCity()),
 			SubcategoryResponseDto.from(product.getSubcategory()),

--- a/src/main/java/taco/klkl/domain/product/dto/response/ProductSimpleResponseDto.java
+++ b/src/main/java/taco/klkl/domain/product/dto/response/ProductSimpleResponseDto.java
@@ -13,13 +13,15 @@ import taco.klkl.domain.product.domain.ProductFilter;
  * @param id
  * @param name
  * @param likeCount
+ * @param rating
  * @param countryName
  * @param categoryName
  */
 public record ProductSimpleResponseDto(
 	Long id,
 	String name,
-	int likeCount,
+	Integer likeCount,
+	Double rating,
 	String countryName,
 	String categoryName,
 	Set<FilterResponseDto> filters
@@ -35,6 +37,7 @@ public record ProductSimpleResponseDto(
 			product.getId(),
 			product.getName(),
 			product.getLikeCount(),
+			product.getRating().getValue(),
 			product.getCity().getCountry().getName().getKoreanName(),
 			product.getSubcategory().getCategory().getName().getKoreanName(),
 			filters

--- a/src/main/java/taco/klkl/domain/product/exception/RatingNotFoundException.java
+++ b/src/main/java/taco/klkl/domain/product/exception/RatingNotFoundException.java
@@ -1,0 +1,10 @@
+package taco.klkl.domain.product.exception;
+
+import taco.klkl.global.error.exception.CustomException;
+import taco.klkl.global.error.exception.ErrorCode;
+
+public class RatingNotFoundException extends CustomException {
+	public RatingNotFoundException() {
+		super(ErrorCode.RATING_NOT_FOUND);
+	}
+}

--- a/src/main/java/taco/klkl/domain/product/service/ProductService.java
+++ b/src/main/java/taco/klkl/domain/product/service/ProductService.java
@@ -25,6 +25,7 @@ import taco.klkl.domain.product.dao.ProductRepository;
 import taco.klkl.domain.product.domain.Product;
 import taco.klkl.domain.product.domain.QProduct;
 import taco.klkl.domain.product.domain.QProductFilter;
+import taco.klkl.domain.product.domain.Rating;
 import taco.klkl.domain.product.dto.request.ProductCreateUpdateRequestDto;
 import taco.klkl.domain.product.dto.request.ProductFilterOptionsDto;
 import taco.klkl.domain.product.dto.response.ProductDetailResponseDto;
@@ -153,6 +154,7 @@ public class ProductService {
 	}
 
 	private Product createProductEntity(final ProductCreateUpdateRequestDto createRequest) {
+		final Rating rating = Rating.from(createRequest.rating());
 		final User user = userUtil.findTestUser();
 		final City city = getCityEntity(createRequest.cityId());
 		final Subcategory subcategory = getSubcategoryEntity(createRequest.subcategoryId());
@@ -163,6 +165,7 @@ public class ProductService {
 			createRequest.description(),
 			createRequest.address(),
 			createRequest.price(),
+			rating,
 			user,
 			city,
 			subcategory,
@@ -171,6 +174,7 @@ public class ProductService {
 	}
 
 	private void updateProductEntity(final Product product, final ProductCreateUpdateRequestDto updateRequest) {
+		final Rating rating = Rating.from(updateRequest.rating());
 		final City city = getCityEntity(updateRequest.cityId());
 		final Subcategory subcategory = getSubcategoryEntity(updateRequest.subcategoryId());
 		final Currency currency = getCurrencyEntity(updateRequest.currencyId());
@@ -180,6 +184,7 @@ public class ProductService {
 			updateRequest.description(),
 			updateRequest.address(),
 			updateRequest.price(),
+			rating,
 			city,
 			subcategory,
 			currency

--- a/src/main/java/taco/klkl/global/common/constants/ProductConstants.java
+++ b/src/main/java/taco/klkl/global/common/constants/ProductConstants.java
@@ -12,6 +12,9 @@ public final class ProductConstants {
 	public static final int DESCRIPTION_MAX_LENGTH = 2000;
 	public static final int ADDRESS_MAX_LENGTH = 100;
 
+	public static final String RATING_MAX_VALUE = "0.5";
+	public static final String RATING_MIN_VALUE = "5.0";
+
 	private ProductConstants() {
 	}
 }

--- a/src/main/java/taco/klkl/global/common/constants/ProductConstants.java
+++ b/src/main/java/taco/klkl/global/common/constants/ProductConstants.java
@@ -12,8 +12,8 @@ public final class ProductConstants {
 	public static final int DESCRIPTION_MAX_LENGTH = 2000;
 	public static final int ADDRESS_MAX_LENGTH = 100;
 
-	public static final String RATING_MAX_VALUE = "0.5";
-	public static final String RATING_MIN_VALUE = "5.0";
+	public static final String RATING_MIN_VALUE = "0.5";
+	public static final String RATING_MAX_VALUE = "5.0";
 
 	private ProductConstants() {
 	}

--- a/src/main/java/taco/klkl/global/common/constants/ProductValidationMessages.java
+++ b/src/main/java/taco/klkl/global/common/constants/ProductValidationMessages.java
@@ -16,6 +16,10 @@ public final class ProductValidationMessages {
 	public static final String PRICE_NOT_NULL = "가격은 필수 항목입니다.";
 	public static final String PRICE_POSITIVE_OR_ZERO = "가격은 0 이상이어야 합니다.";
 
+	public static final String RATING_NOT_NULL = "평점은 필수 항목입니다.";
+	public static final String RATING_UNDER_MIN = "평점은 0.5점보다 낮을 수 없습니다.";
+	public static final String RATING_OVER_MAX = "평점은 5.0점보다 높을 수 없습니다";
+
 	public static final String CITY_ID_NOT_NULL = "도시 ID는 필수 항목입니다.";
 	public static final String SUBCATEGORY_ID_NOT_NULL = "상품 소분류 ID는 필수 항목입니다.";
 	public static final String CURRENCY_ID_NOT_NULL = "통화 ID는 필수 항목입니다.";

--- a/src/main/java/taco/klkl/global/error/exception/ErrorCode.java
+++ b/src/main/java/taco/klkl/global/error/exception/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
 	// Product
 	PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "C020", "존재하지 않는 상품입니다."),
 	INVALID_CITY_IDS(HttpStatus.BAD_REQUEST, "C021", "선택한 도시들은 동일한 국가에 속하지 않습니다."),
+	RATING_NOT_FOUND(HttpStatus.NOT_FOUND, "C022", "존재하지 않는 평점입니다."),
 
 	// Like
 

--- a/src/main/resources/database/data.sql
+++ b/src/main/resources/database/data.sql
@@ -129,11 +129,11 @@ VALUES
 /* Notification */
 
 /* Product */
-INSERT INTO Product(product_id, user_id, name, description, address, price,
+INSERT INTO Product(product_id, user_id, name, description, address, price, rating,
                     city_id, subcategory_id, currency_id, created_at)
 VALUES
-    (101, 1, '곤약젤리', '탱글탱글 맛있는 곤약젤리', '신사이바시 메가돈키호테', 1000, 414, 311, 438, now()),
-    (390, 1, '왕족발 보쌈 과자', '맛있는 왕족발 보쌈 과자', '상하이 장충동', 3000, 422, 311, 439, now());
+    (101, 1, '곤약젤리', '탱글탱글 맛있는 곤약젤리', '신사이바시 메가돈키호테', 1000, 5.0, 414, 311, 438, now()),
+    (390, 1, '왕족발 보쌈 과자', '맛있는 왕족발 보쌈 과자', '상하이 장충동', 3000, 4.5, 422, 311, 439, now());
 
 /* Comment */
 INSERT INTO Comment(comment_id, product_id, user_id, content, created_at)

--- a/src/test/java/taco/klkl/domain/comment/controller/CommentControllerTest.java
+++ b/src/test/java/taco/klkl/domain/comment/controller/CommentControllerTest.java
@@ -30,6 +30,7 @@ import taco.klkl.domain.comment.exception.CommentNotFoundException;
 import taco.klkl.domain.comment.exception.CommentProductNotMatch;
 import taco.klkl.domain.comment.service.CommentService;
 import taco.klkl.domain.product.domain.Product;
+import taco.klkl.domain.product.domain.Rating;
 import taco.klkl.domain.product.exception.ProductNotFoundException;
 import taco.klkl.domain.product.service.ProductService;
 import taco.klkl.domain.region.domain.City;
@@ -105,6 +106,7 @@ public class CommentControllerTest {
 		"description",
 		"address",
 		1000,
+		Rating.FIVE,
 		user,
 		city,
 		subcategory,

--- a/src/test/java/taco/klkl/domain/product/controller/ProductControllerTest.java
+++ b/src/test/java/taco/klkl/domain/product/controller/ProductControllerTest.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import taco.klkl.domain.category.domain.CategoryName;
 import taco.klkl.domain.category.dto.response.FilterResponseDto;
 import taco.klkl.domain.category.dto.response.SubcategoryResponseDto;
+import taco.klkl.domain.product.domain.Rating;
 import taco.klkl.domain.product.dto.request.ProductCreateUpdateRequestDto;
 import taco.klkl.domain.product.dto.request.ProductFilterOptionsDto;
 import taco.klkl.domain.product.dto.response.ProductDetailResponseDto;
@@ -88,6 +89,7 @@ public class ProductControllerTest {
 			1L,
 			"productName",
 			10,
+			Rating.FIVE.getValue(),
 			CountryType.THAILAND.getKoreanName(),
 			CategoryName.FOOD.getKoreanName(),
 			Set.of(filterResponseDto1, filterResponseDto2)
@@ -99,6 +101,7 @@ public class ProductControllerTest {
 			"123 Street",
 			1000,
 			10,
+			Rating.FIVE.getValue(),
 			userDetailResponseDto,
 			cityResponseDto,
 			subcategoryResponseDto,
@@ -111,6 +114,7 @@ public class ProductControllerTest {
 			"productDescription",
 			"productAddress",
 			1000,
+			Rating.FIVE.getValue(),
 			1L,
 			1L,
 			1L,
@@ -144,6 +148,7 @@ public class ProductControllerTest {
 				is(productSimpleResponseDto.id().intValue())))
 			.andExpect(jsonPath("$.data.content[0].name", is(productSimpleResponseDto.name())))
 			.andExpect(jsonPath("$.data.content[0].likeCount", is(productSimpleResponseDto.likeCount())))
+			.andExpect(jsonPath("$.data.content[0].rating", is(productSimpleResponseDto.rating())))
 			.andExpect(jsonPath("$.data.content[0].countryName", is(productSimpleResponseDto.countryName())))
 			.andExpect(jsonPath("$.data.content[0].categoryName",
 				is(productSimpleResponseDto.categoryName())))
@@ -174,6 +179,7 @@ public class ProductControllerTest {
 			.andExpect(jsonPath("$.data.address", is(productDetailResponseDto.address())))
 			.andExpect(jsonPath("$.data.price", is(productDetailResponseDto.price())))
 			.andExpect(jsonPath("$.data.likeCount", is(productDetailResponseDto.likeCount())))
+			.andExpect(jsonPath("$.data.rating", is(productSimpleResponseDto.rating())))
 			.andExpect(jsonPath("$.data.user.id", is(productDetailResponseDto.user().id().intValue())))
 			.andExpect(jsonPath("$.data.user.profile", is(productDetailResponseDto.user().profile())))
 			.andExpect(jsonPath("$.data.user.name", is(productDetailResponseDto.user().name())))
@@ -217,6 +223,7 @@ public class ProductControllerTest {
 			.andExpect(jsonPath("$.data.address", is(productDetailResponseDto.address())))
 			.andExpect(jsonPath("$.data.price", is(productDetailResponseDto.price())))
 			.andExpect(jsonPath("$.data.likeCount", is(productDetailResponseDto.likeCount())))
+			.andExpect(jsonPath("$.data.rating", is(productSimpleResponseDto.rating())))
 			.andExpect(jsonPath("$.data.user.id", is(productDetailResponseDto.user().id().intValue())))
 			.andExpect(jsonPath("$.data.user.profile", is(productDetailResponseDto.user().profile())))
 			.andExpect(jsonPath("$.data.user.name", is(productDetailResponseDto.user().name())))
@@ -260,6 +267,7 @@ public class ProductControllerTest {
 			.andExpect(jsonPath("$.data.address", is(productDetailResponseDto.address())))
 			.andExpect(jsonPath("$.data.price", is(productDetailResponseDto.price())))
 			.andExpect(jsonPath("$.data.likeCount", is(productDetailResponseDto.likeCount())))
+			.andExpect(jsonPath("$.data.rating", is(productSimpleResponseDto.rating())))
 			.andExpect(jsonPath("$.data.user.id", is(productDetailResponseDto.user().id().intValue())))
 			.andExpect(jsonPath("$.data.user.profile", is(productDetailResponseDto.user().profile())))
 			.andExpect(jsonPath("$.data.user.name", is(productDetailResponseDto.user().name())))

--- a/src/test/java/taco/klkl/domain/product/domain/ProductTest.java
+++ b/src/test/java/taco/klkl/domain/product/domain/ProductTest.java
@@ -36,6 +36,7 @@ class ProductTest {
 		String description = "나성공 설명";
 		String address = "나성공 주소";
 		Integer price = 0;
+		Rating rating = Rating.FIVE;
 
 		// when
 		Product product = Product.of(
@@ -43,6 +44,7 @@ class ProductTest {
 			description,
 			address,
 			price,
+			rating,
 			mockUser,
 			mockCity,
 			mockSubcategory,
@@ -56,6 +58,7 @@ class ProductTest {
 		assertThat(product.getAddress()).isEqualTo(address);
 		assertThat(product.getPrice()).isEqualTo(price);
 		assertThat(product.getLikeCount()).isEqualTo(ProductConstants.DEFAULT_LIKE_COUNT);
+		assertThat(product.getRating()).isEqualTo(rating);
 		assertThat(product.getUser()).isEqualTo(mockUser);
 		assertThat(product.getCity()).isEqualTo(mockCity);
 		assertThat(product.getSubcategory()).isEqualTo(mockSubcategory);
@@ -70,6 +73,7 @@ class ProductTest {
 		String description = "설명";
 		String address = null;
 		Integer price = 0;
+		Rating rating = Rating.FIVE;
 
 		// when
 		Product product = Product.of(
@@ -77,6 +81,7 @@ class ProductTest {
 			description,
 			address,
 			price,
+			rating,
 			mockUser,
 			mockCity,
 			mockSubcategory,
@@ -90,6 +95,7 @@ class ProductTest {
 		assertThat(product.getAddress()).isEqualTo(ProductConstants.DEFAULT_ADDRESS);
 		assertThat(product.getPrice()).isEqualTo(price);
 		assertThat(product.getLikeCount()).isEqualTo(ProductConstants.DEFAULT_LIKE_COUNT);
+		assertThat(product.getRating()).isEqualTo(rating);
 		assertThat(product.getUser()).isEqualTo(mockUser);
 		assertThat(product.getCity()).isEqualTo(mockCity);
 		assertThat(product.getSubcategory()).isEqualTo(mockSubcategory);
@@ -104,6 +110,7 @@ class ProductTest {
 		String description = "설명";
 		String address = "주소";
 		Integer price = null;
+		Rating rating = Rating.FIVE;
 
 		// when
 		Product product = Product.of(
@@ -111,6 +118,7 @@ class ProductTest {
 			description,
 			address,
 			price,
+			rating,
 			mockUser,
 			mockCity,
 			mockSubcategory,
@@ -124,6 +132,7 @@ class ProductTest {
 		assertThat(product.getAddress()).isEqualTo(address);
 		assertThat(product.getPrice()).isEqualTo(ProductConstants.DEFAULT_PRICE);
 		assertThat(product.getLikeCount()).isEqualTo(ProductConstants.DEFAULT_LIKE_COUNT);
+		assertThat(product.getRating()).isEqualTo(rating);
 		assertThat(product.getUser()).isEqualTo(mockUser);
 		assertThat(product.getCity()).isEqualTo(mockCity);
 		assertThat(product.getSubcategory()).isEqualTo(mockSubcategory);
@@ -138,6 +147,7 @@ class ProductTest {
 		String originDescription = "Original Description";
 		String originAddress = "Original Address";
 		Integer originPrice = 100;
+		Rating originRating = Rating.FIVE;
 		City originCity = mockCity;
 		Subcategory originSubcategory = mockSubcategory;
 		Currency originCurrency = mockCurrency;
@@ -147,6 +157,7 @@ class ProductTest {
 			originDescription,
 			originAddress,
 			originPrice,
+			originRating,
 			mockUser,
 			originCity,
 			originSubcategory,
@@ -158,6 +169,7 @@ class ProductTest {
 		String updatedDescription = "Updated Description";
 		String updatedAddress = "Updated Address";
 		Integer updatedPrice = 200;
+		Rating updatedRating = Rating.FOUR_FIVE;
 		City updatedCity = mock(City.class);
 		Subcategory updatedSubcategory = mock(Subcategory.class);
 		Currency updatedCurrency = mock(Currency.class);
@@ -167,6 +179,7 @@ class ProductTest {
 			updatedDescription,
 			updatedAddress,
 			updatedPrice,
+			updatedRating,
 			updatedCity,
 			updatedSubcategory,
 			updatedCurrency
@@ -177,6 +190,7 @@ class ProductTest {
 		assertThat(product.getDescription()).isEqualTo(updatedDescription);
 		assertThat(product.getAddress()).isEqualTo(updatedAddress);
 		assertThat(product.getPrice()).isEqualTo(updatedPrice);
+		assertThat(product.getRating()).isEqualTo(updatedRating);
 		assertThat(product.getCity()).isEqualTo(updatedCity);
 		assertThat(product.getSubcategory()).isEqualTo(updatedSubcategory);
 		assertThat(product.getCurrency()).isEqualTo(updatedCurrency);

--- a/src/test/java/taco/klkl/domain/product/dto/request/ProductCreateUpdateRequestDtoTest.java
+++ b/src/test/java/taco/klkl/domain/product/dto/request/ProductCreateUpdateRequestDtoTest.java
@@ -35,6 +35,7 @@ class ProductCreateUpdateRequestDtoTest {
 			"Valid product description",
 			"Valid address",
 			100,
+			5.0,
 			1L,
 			2L,
 			3L,
@@ -53,6 +54,7 @@ class ProductCreateUpdateRequestDtoTest {
 			"Valid product description",
 			"Valid address",
 			100,
+			5.0,
 			1L,
 			2L,
 			3L,
@@ -75,6 +77,7 @@ class ProductCreateUpdateRequestDtoTest {
 			"Valid product description",
 			"Valid address",
 			100,
+			5.0,
 			1L,
 			2L,
 			3L,
@@ -99,6 +102,7 @@ class ProductCreateUpdateRequestDtoTest {
 			"Valid product description",
 			"Valid address",
 			100,
+			5.0,
 			1L,
 			2L,
 			3L,
@@ -118,6 +122,7 @@ class ProductCreateUpdateRequestDtoTest {
 			null,
 			"Valid address",
 			100,
+			5.0,
 			1L,
 			2L,
 			3L,
@@ -140,6 +145,7 @@ class ProductCreateUpdateRequestDtoTest {
 			"",
 			"Valid address",
 			100,
+			5.0,
 			1L,
 			2L,
 			3L,
@@ -164,6 +170,7 @@ class ProductCreateUpdateRequestDtoTest {
 			longDescription,
 			"Valid address",
 			100,
+			5.0,
 			1L,
 			2L,
 			3L,
@@ -183,6 +190,7 @@ class ProductCreateUpdateRequestDtoTest {
 			"Valid product description",
 			null,
 			100,
+			5.0,
 			1L,
 			2L,
 			3L,
@@ -205,6 +213,7 @@ class ProductCreateUpdateRequestDtoTest {
 			"Valid product description",
 			"",
 			100,
+			5.0,
 			1L,
 			2L,
 			3L,
@@ -225,6 +234,7 @@ class ProductCreateUpdateRequestDtoTest {
 			"Valid product description",
 			address,
 			100,
+			5.0,
 			1L,
 			2L,
 			3L,
@@ -245,6 +255,7 @@ class ProductCreateUpdateRequestDtoTest {
 			"Valid product description",
 			longAddress,
 			100,
+			5.0,
 			1L,
 			2L,
 			3L,
@@ -264,6 +275,7 @@ class ProductCreateUpdateRequestDtoTest {
 			"Valid product description",
 			"Valid address",
 			null,
+			5.0,
 			1L,
 			2L,
 			3L,
@@ -287,6 +299,7 @@ class ProductCreateUpdateRequestDtoTest {
 			"Valid product description",
 			"Valid address",
 			0,
+			5.0,
 			1L,
 			2L,
 			3L,
@@ -306,6 +319,7 @@ class ProductCreateUpdateRequestDtoTest {
 			"Valid product description",
 			"Valid address",
 			price,
+			5.0,
 			1L,
 			2L,
 			3L,
@@ -318,6 +332,66 @@ class ProductCreateUpdateRequestDtoTest {
 	}
 
 	@Test
+	@DisplayName("평점이 null일 때 검증 실패")
+	void testNullRating() {
+		ProductCreateUpdateRequestDto requestDto = new ProductCreateUpdateRequestDto(
+			"Valid Product Name",
+			"Valid product description",
+			"Valid address",
+			100,
+			null,
+			1L,
+			2L,
+			3L,
+			Set.of(1L, 2L)
+		);
+
+		Set<ConstraintViolation<ProductCreateUpdateRequestDto>> violations = validator.validate(requestDto);
+		assertFalse(violations.isEmpty());
+		assertEquals(ProductValidationMessages.RATING_NOT_NULL, violations.iterator().next().getMessage());
+	}
+
+	@Test
+	@DisplayName("평점이 최댓값보다 클 때 검증 실패")
+	void testRatingOverMaxValue() {
+		ProductCreateUpdateRequestDto requestDto = new ProductCreateUpdateRequestDto(
+			"Valid Product Name",
+			"Valid product description",
+			"Valid address",
+			100,
+			5.5,
+			1L,
+			2L,
+			3L,
+			Set.of(1L, 2L)
+		);
+
+		Set<ConstraintViolation<ProductCreateUpdateRequestDto>> violations = validator.validate(requestDto);
+		assertFalse(violations.isEmpty());
+		assertEquals(ProductValidationMessages.RATING_OVER_MAX, violations.iterator().next().getMessage());
+	}
+
+	@Test
+	@DisplayName("평점이 최솟값보다 작을 때 검증 실패")
+	void testRatingUnderMinValue() {
+		ProductCreateUpdateRequestDto requestDto = new ProductCreateUpdateRequestDto(
+			"Valid Product Name",
+			"Valid product description",
+			"Valid address",
+			100,
+			0.0,
+			1L,
+			2L,
+			3L,
+			Set.of(1L, 2L)
+		);
+
+		Set<ConstraintViolation<ProductCreateUpdateRequestDto>> violations = validator.validate(requestDto);
+		assertFalse(violations.isEmpty());
+		assertEquals(ProductValidationMessages.RATING_UNDER_MIN, violations.iterator().next().getMessage());
+	}
+
+	@Test
 	@DisplayName("도시 ID가 null일 때 검증 실패")
 	void testNullCityId() {
 		ProductCreateUpdateRequestDto requestDto = new ProductCreateUpdateRequestDto(
@@ -325,6 +399,7 @@ class ProductCreateUpdateRequestDtoTest {
 			"Valid product description",
 			"Valid address",
 			100,
+			5.0,
 			null,
 			2L,
 			3L,
@@ -344,6 +419,7 @@ class ProductCreateUpdateRequestDtoTest {
 			"Valid product description",
 			"Valid address",
 			100,
+			5.0,
 			1L,
 			null,
 			3L,
@@ -363,6 +439,7 @@ class ProductCreateUpdateRequestDtoTest {
 			"Valid product description",
 			"Valid address",
 			100,
+			5.0,
 			1L,
 			2L,
 			null,
@@ -382,6 +459,7 @@ class ProductCreateUpdateRequestDtoTest {
 			"Valid product description",
 			"Valid address",
 			100,
+			5.0,
 			1L,
 			2L,
 			3L,

--- a/src/test/java/taco/klkl/domain/product/dto/response/ProductDetailResponseDtoTest.java
+++ b/src/test/java/taco/klkl/domain/product/dto/response/ProductDetailResponseDtoTest.java
@@ -12,6 +12,7 @@ import taco.klkl.domain.category.domain.Subcategory;
 import taco.klkl.domain.category.domain.SubcategoryName;
 import taco.klkl.domain.category.dto.response.SubcategoryResponseDto;
 import taco.klkl.domain.product.domain.Product;
+import taco.klkl.domain.product.domain.Rating;
 import taco.klkl.domain.region.domain.City;
 import taco.klkl.domain.region.domain.Currency;
 import taco.klkl.domain.region.dto.response.CityResponseDto;
@@ -57,6 +58,7 @@ class ProductDetailResponseDtoTest {
 		when(mockProduct.getAddress()).thenReturn("productAddress");
 		when(mockProduct.getPrice()).thenReturn(1000);
 		when(mockProduct.getLikeCount()).thenReturn(0);
+		when(mockProduct.getRating()).thenReturn(Rating.FIVE);
 		when(mockProduct.getUser()).thenReturn(mockUser);
 		when(mockProduct.getCity()).thenReturn(mockCity);
 		when(mockProduct.getSubcategory()).thenReturn(mockSubcategory);
@@ -76,6 +78,7 @@ class ProductDetailResponseDtoTest {
 		assertThat(dto.address()).isEqualTo(mockProduct.getAddress());
 		assertThat(dto.price()).isEqualTo(mockProduct.getPrice());
 		assertThat(dto.likeCount()).isEqualTo(mockProduct.getLikeCount());
+		assertThat(dto.rating()).isEqualTo(mockProduct.getRating().getValue());
 		assertThat(dto.user()).isEqualTo(UserDetailResponseDto.from(mockUser));
 		assertThat(dto.city()).isEqualTo(CityResponseDto.from(mockCity));
 		assertThat(dto.subcategory()).isEqualTo(SubcategoryResponseDto.from(mockSubcategory));
@@ -95,6 +98,7 @@ class ProductDetailResponseDtoTest {
 		assertThat(dto.address()).isEqualTo(mockProduct.getAddress());
 		assertThat(dto.price()).isEqualTo(mockProduct.getPrice());
 		assertThat(dto.likeCount()).isEqualTo(mockProduct.getLikeCount());
+		assertThat(dto.rating()).isEqualTo(mockProduct.getRating().getValue());
 		assertThat(dto.user()).isEqualTo(UserDetailResponseDto.from(mockUser));
 		assertThat(dto.city()).isEqualTo(CityResponseDto.from(mockCity));
 		assertThat(dto.subcategory()).isEqualTo(SubcategoryResponseDto.from(mockSubcategory));

--- a/src/test/java/taco/klkl/domain/product/dto/response/ProductSimpleResponseDtoTest.java
+++ b/src/test/java/taco/klkl/domain/product/dto/response/ProductSimpleResponseDtoTest.java
@@ -20,6 +20,7 @@ import taco.klkl.domain.category.domain.SubcategoryName;
 import taco.klkl.domain.category.dto.response.FilterResponseDto;
 import taco.klkl.domain.product.domain.Product;
 import taco.klkl.domain.product.domain.ProductFilter;
+import taco.klkl.domain.product.domain.Rating;
 import taco.klkl.domain.region.domain.City;
 import taco.klkl.domain.region.domain.Country;
 import taco.klkl.domain.region.domain.Currency;
@@ -82,6 +83,7 @@ class ProductSimpleResponseDtoTest {
 		when(product.getAddress()).thenReturn("productAddress");
 		when(product.getPrice()).thenReturn(1000);
 		when(product.getLikeCount()).thenReturn(0);
+		when(product.getRating()).thenReturn(Rating.FIVE);
 		when(product.getUser()).thenReturn(mockUser);
 		when(product.getCity()).thenReturn(city);
 		when(product.getSubcategory()).thenReturn(subcategory);
@@ -99,6 +101,7 @@ class ProductSimpleResponseDtoTest {
 		assertThat(dto.id()).isEqualTo(product.getId());
 		assertThat(dto.name()).isEqualTo(product.getName());
 		assertThat(dto.likeCount()).isEqualTo(product.getLikeCount());
+		assertThat(dto.rating()).isEqualTo(product.getRating().getValue());
 		assertThat(dto.countryName()).isEqualTo(product.getCity().getCountry().getName().getKoreanName());
 		assertThat(dto.categoryName()).isEqualTo(product.getSubcategory().getCategory().getName().getKoreanName());
 	}
@@ -116,6 +119,7 @@ class ProductSimpleResponseDtoTest {
 			product.getId(),
 			product.getName(),
 			product.getLikeCount(),
+			product.getRating().getValue(),
 			city.getCountry().getName().getKoreanName(),
 			product.getSubcategory().getCategory().getName().getKoreanName(),
 			filters
@@ -125,6 +129,7 @@ class ProductSimpleResponseDtoTest {
 		assertThat(dto.id()).isEqualTo(product.getId());
 		assertThat(dto.name()).isEqualTo(product.getName());
 		assertThat(dto.likeCount()).isEqualTo(product.getLikeCount());
+		assertThat(dto.rating()).isEqualTo(product.getRating().getValue());
 		assertThat(dto.countryName()).isEqualTo(city.getCountry().getName().getKoreanName());
 		assertThat(dto.categoryName()).isEqualTo(product.getSubcategory().getCategory().getName().getKoreanName());
 	}

--- a/src/test/java/taco/klkl/domain/product/integration/ProductIntegrationTest.java
+++ b/src/test/java/taco/klkl/domain/product/integration/ProductIntegrationTest.java
@@ -47,6 +47,7 @@ public class ProductIntegrationTest {
 			"description",
 			"address",
 			1000,
+			5.0,
 			414L,
 			310L,
 			438L,
@@ -66,6 +67,7 @@ public class ProductIntegrationTest {
 			.andExpect(jsonPath("$.data.address", is(createRequest.address())))
 			.andExpect(jsonPath("$.data.price", is(createRequest.price())))
 			.andExpect(jsonPath("$.data.likeCount", is(ProductConstants.DEFAULT_LIKE_COUNT)))
+			.andExpect(jsonPath("$.data.rating", is(createRequest.rating())))
 			.andExpect(jsonPath("$.data.user.id", notNullValue()))
 			.andExpect(jsonPath("$.data.city.cityId", is(createRequest.cityId().intValue())))
 			.andExpect(jsonPath("$.data.subcategory.subcategoryId", is(createRequest.subcategoryId().intValue())))
@@ -83,6 +85,7 @@ public class ProductIntegrationTest {
 			"description",
 			"address",
 			1000,
+			5.0,
 			414L,
 			310L,
 			438L,
@@ -102,6 +105,7 @@ public class ProductIntegrationTest {
 			.andExpect(jsonPath("$.data.address", is(createRequest.address())))
 			.andExpect(jsonPath("$.data.price", is(createRequest.price())))
 			.andExpect(jsonPath("$.data.likeCount", is(ProductConstants.DEFAULT_LIKE_COUNT)))
+			.andExpect(jsonPath("$.data.rating", is(createRequest.rating())))
 			.andExpect(jsonPath("$.data.user.id", notNullValue()))
 			.andExpect(jsonPath("$.data.city.cityId", is(createRequest.cityId().intValue())))
 			.andExpect(jsonPath("$.data.subcategory.subcategoryId", is(createRequest.subcategoryId().intValue())))
@@ -119,6 +123,7 @@ public class ProductIntegrationTest {
 			"description1",
 			"address1",
 			1000,
+			5.0,
 			414L,
 			310L,
 			438L,
@@ -129,6 +134,7 @@ public class ProductIntegrationTest {
 			"description2",
 			"address2",
 			2000,
+			5.0,
 			415L,
 			311L,
 			438L,
@@ -165,6 +171,7 @@ public class ProductIntegrationTest {
 			"description1",
 			"address1",
 			1000,
+			5.0,
 			414L,
 			310L,
 			438L,
@@ -175,6 +182,7 @@ public class ProductIntegrationTest {
 			"description2",
 			"address2",
 			2000,
+			5.0,
 			414L,
 			311L,
 			438L,
@@ -185,6 +193,7 @@ public class ProductIntegrationTest {
 			"description3",
 			"address3",
 			2000,
+			5.0,
 			416L,
 			311L,
 			438L,
@@ -220,6 +229,7 @@ public class ProductIntegrationTest {
 			"description1",
 			"address1",
 			1000,
+			5.0,
 			415L,
 			310L,
 			438L,
@@ -230,6 +240,7 @@ public class ProductIntegrationTest {
 			"description2",
 			"address2",
 			2000,
+			5.0,
 			415L,
 			311L,
 			438L,
@@ -240,6 +251,7 @@ public class ProductIntegrationTest {
 			"description3",
 			"address3",
 			2000,
+			5.0,
 			416L,
 			311L,
 			438L,
@@ -277,6 +289,7 @@ public class ProductIntegrationTest {
 			"description1",
 			"address1",
 			1000,
+			5.0,
 			415L,
 			310L,
 			438L,
@@ -287,6 +300,7 @@ public class ProductIntegrationTest {
 			"description2",
 			"address2",
 			2000,
+			5.0,
 			431L,
 			310L,
 			442L,
@@ -297,6 +311,7 @@ public class ProductIntegrationTest {
 			"description3",
 			"address3",
 			3000,
+			5.0,
 			416L,
 			324L,
 			438L,
@@ -307,6 +322,7 @@ public class ProductIntegrationTest {
 			"description4",
 			"address4",
 			4000,
+			5.0,
 			423L,
 			315L,
 			439L,
@@ -344,6 +360,7 @@ public class ProductIntegrationTest {
 			"description1",
 			"address1",
 			1000,
+			5.0,
 			415L,
 			310L,
 			438L,
@@ -354,6 +371,7 @@ public class ProductIntegrationTest {
 			"description2",
 			"address2",
 			2000,
+			5.0,
 			431L,
 			310L,
 			442L,
@@ -364,6 +382,7 @@ public class ProductIntegrationTest {
 			"description3",
 			"address3",
 			3000,
+			5.0,
 			416L,
 			324L,
 			438L,
@@ -374,6 +393,7 @@ public class ProductIntegrationTest {
 			"description4",
 			"address4",
 			4000,
+			5.0,
 			423L,
 			315L,
 			439L,
@@ -412,6 +432,7 @@ public class ProductIntegrationTest {
 			"description1",
 			"address1",
 			1000,
+			5.0,
 			415L,
 			310L,
 			438L,
@@ -422,6 +443,7 @@ public class ProductIntegrationTest {
 			"description2",
 			"address2",
 			2000,
+			5.0,
 			431L,
 			310L,
 			442L,
@@ -432,6 +454,7 @@ public class ProductIntegrationTest {
 			"description3",
 			"address3",
 			3000,
+			5.0,
 			416L,
 			324L,
 			438L,
@@ -442,6 +465,7 @@ public class ProductIntegrationTest {
 			"description4",
 			"address4",
 			4000,
+			5.0,
 			423L,
 			315L,
 			439L,
@@ -479,6 +503,7 @@ public class ProductIntegrationTest {
 			"description1",
 			"address1",
 			1000,
+			5.0,
 			415L,
 			310L,
 			438L,
@@ -489,6 +514,7 @@ public class ProductIntegrationTest {
 			"description2",
 			"address2",
 			2000,
+			5.0,
 			431L,
 			310L,
 			442L,
@@ -499,6 +525,7 @@ public class ProductIntegrationTest {
 			"description3",
 			"address3",
 			3000,
+			5.0,
 			416L,
 			324L,
 			438L,
@@ -509,6 +536,7 @@ public class ProductIntegrationTest {
 			"description4",
 			"address4",
 			4000,
+			5.0,
 			423L,
 			315L,
 			439L,
@@ -547,6 +575,7 @@ public class ProductIntegrationTest {
 			"description",
 			"address",
 			1000,
+			5.0,
 			414L,
 			310L,
 			438L,
@@ -559,6 +588,7 @@ public class ProductIntegrationTest {
 			"Updated Description",
 			"Updated Address",
 			2000,
+			4.5,
 			415L,
 			310L,
 			438L,
@@ -578,6 +608,7 @@ public class ProductIntegrationTest {
 			.andExpect(jsonPath("$.data.address", is(updateRequest.address())))
 			.andExpect(jsonPath("$.data.price", is(updateRequest.price())))
 			.andExpect(jsonPath("$.data.likeCount", is(ProductConstants.DEFAULT_LIKE_COUNT)))
+			.andExpect(jsonPath("$.data.rating", is(updateRequest.rating())))
 			.andExpect(jsonPath("$.data.user.id", is(productDto.user().id().intValue())))
 			.andExpect(jsonPath("$.data.city.cityId", is(updateRequest.cityId().intValue())))
 			.andExpect(jsonPath("$.data.subcategory.subcategoryId",
@@ -596,6 +627,7 @@ public class ProductIntegrationTest {
 			"description",
 			"address",
 			1000,
+			5.0,
 			414L,
 			310L,
 			438L,

--- a/src/test/java/taco/klkl/domain/product/service/ProductServiceTest.java
+++ b/src/test/java/taco/klkl/domain/product/service/ProductServiceTest.java
@@ -37,6 +37,7 @@ import taco.klkl.domain.product.domain.Product;
 import taco.klkl.domain.product.domain.ProductFilter;
 import taco.klkl.domain.product.domain.QProduct;
 import taco.klkl.domain.product.domain.QProductFilter;
+import taco.klkl.domain.product.domain.Rating;
 import taco.klkl.domain.product.dto.request.ProductCreateUpdateRequestDto;
 import taco.klkl.domain.product.dto.request.ProductFilterOptionsDto;
 import taco.klkl.domain.product.dto.response.ProductDetailResponseDto;
@@ -124,6 +125,7 @@ class ProductServiceTest {
 			"description",
 			"address",
 			1000,
+			Rating.FIVE,
 			user,
 			city,
 			subcategory,
@@ -135,6 +137,7 @@ class ProductServiceTest {
 			"productDescription",
 			"productAddress",
 			1000,
+			5.0,
 			1L,
 			1L,
 			1L,
@@ -238,6 +241,7 @@ class ProductServiceTest {
 		assertThat(result.description()).isEqualTo(testProduct.getDescription());
 		assertThat(result.address()).isEqualTo(testProduct.getAddress());
 		assertThat(result.price()).isEqualTo(testProduct.getPrice());
+		assertThat(result.rating()).isEqualTo(testProduct.getRating().getValue());
 
 		// 필터 검증
 		if (testProduct.getProductFilters() != null && !testProduct.getProductFilters().isEmpty()) {
@@ -303,6 +307,7 @@ class ProductServiceTest {
 			assertThat(savedProduct.getDescription()).isEqualTo(requestDto.description());
 			assertThat(savedProduct.getAddress()).isEqualTo(requestDto.address());
 			assertThat(savedProduct.getPrice()).isEqualTo(requestDto.price());
+			assertThat(savedProduct.getRating().getValue()).isEqualTo(requestDto.rating());
 			assertThat(savedProduct.getUser()).isEqualTo(user);
 			assertThat(savedProduct.getCity()).isEqualTo(city);
 			assertThat(savedProduct.getSubcategory()).isEqualTo(subcategory);


### PR DESCRIPTION
## 📌 연관된 이슈
- **[KL-131/상품에 평점 필드 추가](https://ohhamma.atlassian.net/browse/KL-131)**

## 📝 작업 내용
- `Rating` enum 추가 및 관련 예외 생성
- 상품에 `rating` 필드 추가 및 `RatingConverter` 작성
- 요청 및 응답 dto에도 `rating` 필드 추가
- 더미데이터에도 `rating` 추가
- 관련 테스트코드 추가 및 수정

## 🌳 작업 브랜치명
- `KL-131/상품에-평점-필드-추가`

## 📸 스크린샷 (선택)

## 💬 리뷰 요구사항 (선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a rating system for products, allowing users to assign ratings from 0.5 to 5.0.
	- Added functionality to create and update products with ratings through the application.

- **Bug Fixes**
	- Enhanced error handling for scenarios where a rating cannot be found, introducing a specific exception.

- **Documentation**
	- Updated documentation for data transfer objects to include the new rating field.

- **Tests**
	- Expanded test coverage to validate the new rating feature in various product-related tests, ensuring accurate functionality and integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->