### PR TITLE
feat(KL-94): sort products

### DIFF
--- a/src/main/java/taco/klkl/domain/product/controller/ProductController.java
+++ b/src/main/java/taco/klkl/domain/product/controller/ProductController.java
@@ -23,6 +23,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import taco.klkl.domain.product.dto.request.ProductCreateUpdateRequestDto;
 import taco.klkl.domain.product.dto.request.ProductFilterOptionsDto;
+import taco.klkl.domain.product.dto.request.ProductSortOptionsDto;
 import taco.klkl.domain.product.dto.response.ProductDetailResponseDto;
 import taco.klkl.domain.product.dto.response.ProductSimpleResponseDto;
 import taco.klkl.domain.product.service.ProductService;
@@ -43,14 +44,20 @@ public class ProductController {
 		@PageableDefault(size = ProductConstants.DEFAULT_PAGE_SIZE) Pageable pageable,
 		@RequestParam(name = "city_id", required = false) Set<Long> cityIds,
 		@RequestParam(name = "subcategory_id", required = false) Set<Long> subcategoryIds,
-		@RequestParam(name = "filter_id", required = false) Set<Long> filterIds
+		@RequestParam(name = "filter_id", required = false) Set<Long> filterIds,
+		@RequestParam(name = "sort_by", required = false, defaultValue = "createdAt") String sortBy,
+		@RequestParam(name = "sort_direction", required = false, defaultValue = "DESC") String sortDirection
 	) {
 		ProductFilterOptionsDto filterOptions = new ProductFilterOptionsDto(
 			cityIds,
 			subcategoryIds,
 			filterIds
 		);
-		return productService.getProductsByFilterOptions(pageable, filterOptions);
+		ProductSortOptionsDto sortOptions = new ProductSortOptionsDto(
+			sortBy,
+			sortDirection
+		);
+		return productService.getProductsByFilterOptions(pageable, filterOptions, sortOptions);
 	}
 
 	@GetMapping("/{id}")

--- a/src/main/java/taco/klkl/domain/product/dto/request/ProductSortOptionsDto.java
+++ b/src/main/java/taco/klkl/domain/product/dto/request/ProductSortOptionsDto.java
@@ -1,0 +1,7 @@
+package taco.klkl.domain.product.dto.request;
+
+public record ProductSortOptionsDto(
+	String sortBy,
+	String sortDirection
+) {
+}

--- a/src/main/java/taco/klkl/domain/product/exception/InvalidSortOptionException.java
+++ b/src/main/java/taco/klkl/domain/product/exception/InvalidSortOptionException.java
@@ -1,0 +1,10 @@
+package taco.klkl.domain.product.exception;
+
+import taco.klkl.global.error.exception.CustomException;
+import taco.klkl.global.error.exception.ErrorCode;
+
+public class InvalidSortOptionException extends CustomException {
+	public InvalidSortOptionException() {
+		super(ErrorCode.INVALID_SORT_OPTION);
+	}
+}

--- a/src/main/java/taco/klkl/global/common/constants/ProductConstants.java
+++ b/src/main/java/taco/klkl/global/common/constants/ProductConstants.java
@@ -1,5 +1,7 @@
 package taco.klkl.global.common.constants;
 
+import java.util.Set;
+
 public final class ProductConstants {
 
 	public static final int DEFAULT_PAGE_SIZE = 9;
@@ -14,6 +16,9 @@ public final class ProductConstants {
 
 	public static final String RATING_MIN_VALUE = "0.5";
 	public static final String RATING_MAX_VALUE = "5.0";
+
+	public static final Set<String> ALLOWED_SORT_BY = Set.of("likeCount", "rating", "createdAt");
+	public static final Set<String> ALLOWED_SORT_DIRECTION = Set.of("ASC", "DESC");
 
 	private ProductConstants() {
 	}

--- a/src/main/java/taco/klkl/global/error/exception/ErrorCode.java
+++ b/src/main/java/taco/klkl/global/error/exception/ErrorCode.java
@@ -21,8 +21,9 @@ public enum ErrorCode {
 
 	// Product
 	PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "C020", "존재하지 않는 상품입니다."),
-	INVALID_CITY_IDS(HttpStatus.BAD_REQUEST, "C021", "선택한 도시들은 동일한 국가에 속하지 않습니다."),
-	RATING_NOT_FOUND(HttpStatus.NOT_FOUND, "C022", "존재하지 않는 평점입니다."),
+	RATING_NOT_FOUND(HttpStatus.NOT_FOUND, "C021", "존재하지 않는 평점입니다."),
+	INVALID_CITY_IDS(HttpStatus.BAD_REQUEST, "C022", "선택한 도시들은 동일한 국가에 속하지 않습니다."),
+	INVALID_SORT_OPTION(HttpStatus.BAD_REQUEST, "C023", "유효하지 않은 정렬 옵션입니다."),
 
 	// Like
 

--- a/src/main/resources/database/data.sql
+++ b/src/main/resources/database/data.sql
@@ -129,11 +129,11 @@ VALUES
 /* Notification */
 
 /* Product */
-INSERT INTO Product(product_id, user_id, name, description, address, price, rating,
+INSERT INTO Product(product_id, user_id, name, description, address, price, like_count, rating,
                     city_id, subcategory_id, currency_id, created_at)
-VALUES
-    (101, 1, '곤약젤리', '탱글탱글 맛있는 곤약젤리', '신사이바시 메가돈키호테', 1000, 5.0, 414, 311, 438, now()),
-    (390, 1, '왕족발 보쌈 과자', '맛있는 왕족발 보쌈 과자', '상하이 장충동', 3000, 4.5, 422, 311, 439, now());
+VALUES (101, 1, '곤약젤리', '탱글탱글 맛있는 곤약젤리', '신사이바시 메가돈키호테', 1000, 100, 5.0, 414, 311, 438, now()),
+       (102, 1, '여름 원피스', '시원하고 여름 휴양지 느낌의 원피스', '방콕 짜뚜짝 시장', 300, 333, 4.5, 425, 323, 441, now()),
+       (390, 1, '왕족발 보쌈 과자', '맛있는 왕족발 보쌈 과자', '상하이 장충동', 3000, 10, 3.0, 422, 311, 439, now());
 
 /* Comment */
 INSERT INTO Comment(comment_id, product_id, user_id, content, created_at)

--- a/src/test/java/taco/klkl/domain/product/integration/ProductIntegrationTest.java
+++ b/src/test/java/taco/klkl/domain/product/integration/ProductIntegrationTest.java
@@ -151,12 +151,12 @@ public class ProductIntegrationTest {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.isSuccess", is(true)))
 			.andExpect(jsonPath("$.code", is("C000")))
-			.andExpect(jsonPath("$.data.content", hasSize(4)))
-			.andExpect(jsonPath("$.data.content[0].name", is(createRequest1.name())))
-			.andExpect(jsonPath("$.data.content[1].name", is(createRequest2.name())))
+			.andExpect(jsonPath("$.data.content", hasSize(5)))
+			.andExpect(jsonPath("$.data.content[0].name", is(createRequest2.name())))
+			.andExpect(jsonPath("$.data.content[1].name", is(createRequest1.name())))
 			.andExpect(jsonPath("$.data.pageNumber", is(0)))
 			.andExpect(jsonPath("$.data.pageSize", is(10)))
-			.andExpect(jsonPath("$.data.totalElements", is(4)))
+			.andExpect(jsonPath("$.data.totalElements", is(5)))
 			.andExpect(jsonPath("$.data.totalPages", is(1)))
 			.andExpect(jsonPath("$.data.last", is(true)))
 			.andExpect(jsonPath("$.timestamp", notNullValue()));
@@ -206,6 +206,8 @@ public class ProductIntegrationTest {
 		// when & then
 		mockMvc.perform(get("/v1/products")
 				.param("city_id", "416")  // 도쿄
+				.param("sort_by", "createdAt")
+				.param("sort_direction", "ASC")
 				.contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.isSuccess", is(true)))
@@ -264,6 +266,8 @@ public class ProductIntegrationTest {
 		// when & then
 		mockMvc.perform(get("/v1/products")
 				.param("city_id", "415", "416")  // 교토, 도쿄
+				.param("sort_by", "createdAt")
+				.param("sort_direction", "ASC")
 				.contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.isSuccess", is(true)))
@@ -336,6 +340,8 @@ public class ProductIntegrationTest {
 		// when & then
 		mockMvc.perform(get("/v1/products")
 				.param("subcategory_id", "310")  // 라면
+				.param("sort_by", "createdAt")
+				.param("sort_direction", "ASC")
 				.contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.isSuccess", is(true)))
@@ -407,6 +413,8 @@ public class ProductIntegrationTest {
 		// when & then
 		mockMvc.perform(get("/v1/products")
 				.param("subcategory_id", "310", "324")  // 라면, 신발
+				.param("sort_by", "createdAt")
+				.param("sort_direction", "ASC")
 				.contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.isSuccess", is(true)))
@@ -479,6 +487,8 @@ public class ProductIntegrationTest {
 		// when & then
 		mockMvc.perform(get("/v1/products")
 				.param("filter_id", "351")  // 고수
+				.param("sort_by", "createdAt")
+				.param("sort_direction", "ASC")
 				.contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.isSuccess", is(true)))
@@ -550,6 +560,8 @@ public class ProductIntegrationTest {
 		// when & then
 		mockMvc.perform(get("/v1/products")
 				.param("filter_id", "351", "350")  // 고수, 편의점
+				.param("sort_by", "createdAt")
+				.param("sort_direction", "ASC")
 				.contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.isSuccess", is(true)))

--- a/src/test/java/taco/klkl/domain/product/integration/ProductIntegrationTest.java
+++ b/src/test/java/taco/klkl/domain/product/integration/ProductIntegrationTest.java
@@ -579,6 +579,352 @@ public class ProductIntegrationTest {
 	}
 
 	@Test
+	@DisplayName("생성된 날짜로 오름차순 정렬된 상품 목록 조회 API 테스트")
+	public void testSortProductsByCreatedAtAsc() throws Exception {
+		// given
+		ProductCreateUpdateRequestDto createRequest1 = new ProductCreateUpdateRequestDto(
+			"name1",
+			"description1",
+			"address1",
+			1000,
+			5.0,
+			415L,
+			310L,
+			438L,
+			Set.of(351L)
+		);
+		ProductCreateUpdateRequestDto createRequest2 = new ProductCreateUpdateRequestDto(
+			"name2",
+			"description2",
+			"address2",
+			2000,
+			5.0,
+			431L,
+			310L,
+			442L,
+			Set.of(351L)
+		);
+		ProductCreateUpdateRequestDto createRequest3 = new ProductCreateUpdateRequestDto(
+			"name3",
+			"description3",
+			"address3",
+			3000,
+			5.0,
+			416L,
+			324L,
+			438L,
+			Set.of(350L, 351L)
+		);
+		ProductCreateUpdateRequestDto createRequest4 = new ProductCreateUpdateRequestDto(
+			"name4",
+			"description4",
+			"address4",
+			4000,
+			5.0,
+			423L,
+			315L,
+			439L,
+			Set.of(350L)
+		);
+		productService.createProduct(createRequest1);
+		productService.createProduct(createRequest2);
+		productService.createProduct(createRequest3);
+		productService.createProduct(createRequest4);
+
+		// when & then
+		mockMvc.perform(get("/v1/products")
+				.param("filter_id", "351", "350")
+				.param("sort_by", "createdAt")
+				.param("sort_direction", "ASC")
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.isSuccess", is(true)))
+			.andExpect(jsonPath("$.code", is("C000")))
+			.andExpect(jsonPath("$.data.content", hasSize(4)))
+			.andExpect(jsonPath("$.data.content[0].name", is(createRequest1.name())))
+			.andExpect(jsonPath("$.data.content[1].name", is(createRequest2.name())))
+			.andExpect(jsonPath("$.data.content[2].name", is(createRequest3.name())))
+			.andExpect(jsonPath("$.data.content[3].name", is(createRequest4.name())))
+			.andExpect(jsonPath("$.data.pageNumber", is(0)))
+			.andExpect(jsonPath("$.data.pageSize", is(ProductConstants.DEFAULT_PAGE_SIZE)))
+			.andExpect(jsonPath("$.data.totalElements", is(4)))
+			.andExpect(jsonPath("$.data.totalPages", is(1)))
+			.andExpect(jsonPath("$.data.last", is(true)))
+			.andExpect(jsonPath("$.timestamp", notNullValue()));
+	}
+
+	@Test
+	@DisplayName("생성된 날짜로 내림차순 정렬된 상품 목록 조회 API 테스트")
+	public void testSortProductsByCreatedAtDesc() throws Exception {
+		// given
+		ProductCreateUpdateRequestDto createRequest1 = new ProductCreateUpdateRequestDto(
+			"name1",
+			"description1",
+			"address1",
+			1000,
+			5.0,
+			415L,
+			310L,
+			438L,
+			Set.of(351L)
+		);
+		ProductCreateUpdateRequestDto createRequest2 = new ProductCreateUpdateRequestDto(
+			"name2",
+			"description2",
+			"address2",
+			2000,
+			5.0,
+			431L,
+			310L,
+			442L,
+			Set.of(351L)
+		);
+		ProductCreateUpdateRequestDto createRequest3 = new ProductCreateUpdateRequestDto(
+			"name3",
+			"description3",
+			"address3",
+			3000,
+			5.0,
+			416L,
+			324L,
+			438L,
+			Set.of(350L, 351L)
+		);
+		ProductCreateUpdateRequestDto createRequest4 = new ProductCreateUpdateRequestDto(
+			"name4",
+			"description4",
+			"address4",
+			4000,
+			5.0,
+			423L,
+			315L,
+			439L,
+			Set.of(350L)
+		);
+		productService.createProduct(createRequest4);
+		productService.createProduct(createRequest3);
+		productService.createProduct(createRequest2);
+		productService.createProduct(createRequest1);
+
+		// when & then
+		mockMvc.perform(get("/v1/products")
+				.param("filter_id", "351", "350")
+				.param("sort_by", "createdAt")
+				.param("sort_direction", "DESC")
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.isSuccess", is(true)))
+			.andExpect(jsonPath("$.code", is("C000")))
+			.andExpect(jsonPath("$.data.content", hasSize(4)))
+			.andExpect(jsonPath("$.data.content[0].name", is(createRequest1.name())))
+			.andExpect(jsonPath("$.data.content[1].name", is(createRequest2.name())))
+			.andExpect(jsonPath("$.data.content[2].name", is(createRequest3.name())))
+			.andExpect(jsonPath("$.data.content[3].name", is(createRequest4.name())))
+			.andExpect(jsonPath("$.data.pageNumber", is(0)))
+			.andExpect(jsonPath("$.data.pageSize", is(ProductConstants.DEFAULT_PAGE_SIZE)))
+			.andExpect(jsonPath("$.data.totalElements", is(4)))
+			.andExpect(jsonPath("$.data.totalPages", is(1)))
+			.andExpect(jsonPath("$.data.last", is(true)))
+			.andExpect(jsonPath("$.timestamp", notNullValue()));
+	}
+
+	@Test
+	@DisplayName("평점으로 오름차순 정렬된 상품 목록 조회 API 테스트")
+	public void testSortProductsByRatingAsc() throws Exception {
+		// given
+		ProductCreateUpdateRequestDto createRequest1 = new ProductCreateUpdateRequestDto(
+			"name1",
+			"description1",
+			"address1",
+			1000,
+			0.5,
+			415L,
+			310L,
+			438L,
+			Set.of(351L)
+		);
+		ProductCreateUpdateRequestDto createRequest2 = new ProductCreateUpdateRequestDto(
+			"name2",
+			"description2",
+			"address2",
+			2000,
+			2.0,
+			431L,
+			310L,
+			442L,
+			Set.of(351L)
+		);
+		ProductCreateUpdateRequestDto createRequest3 = new ProductCreateUpdateRequestDto(
+			"name3",
+			"description3",
+			"address3",
+			3000,
+			3.5,
+			416L,
+			324L,
+			438L,
+			Set.of(350L, 351L)
+		);
+		ProductCreateUpdateRequestDto createRequest4 = new ProductCreateUpdateRequestDto(
+			"name4",
+			"description4",
+			"address4",
+			4000,
+			5.0,
+			423L,
+			315L,
+			439L,
+			Set.of(350L)
+		);
+		productService.createProduct(createRequest1);
+		productService.createProduct(createRequest2);
+		productService.createProduct(createRequest3);
+		productService.createProduct(createRequest4);
+
+		// when & then
+		mockMvc.perform(get("/v1/products")
+				.param("filter_id", "351", "350")
+				.param("sort_by", "rating")
+				.param("sort_direction", "ASC")
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.isSuccess", is(true)))
+			.andExpect(jsonPath("$.code", is("C000")))
+			.andExpect(jsonPath("$.data.content", hasSize(4)))
+			.andExpect(jsonPath("$.data.content[0].name", is(createRequest1.name())))
+			.andExpect(jsonPath("$.data.content[1].name", is(createRequest2.name())))
+			.andExpect(jsonPath("$.data.content[2].name", is(createRequest3.name())))
+			.andExpect(jsonPath("$.data.content[3].name", is(createRequest4.name())))
+			.andExpect(jsonPath("$.data.pageNumber", is(0)))
+			.andExpect(jsonPath("$.data.pageSize", is(ProductConstants.DEFAULT_PAGE_SIZE)))
+			.andExpect(jsonPath("$.data.totalElements", is(4)))
+			.andExpect(jsonPath("$.data.totalPages", is(1)))
+			.andExpect(jsonPath("$.data.last", is(true)))
+			.andExpect(jsonPath("$.timestamp", notNullValue()));
+	}
+
+	@Test
+	@DisplayName("평점으로 내림차순 정렬된 상품 목록 조회 API 테스트")
+	public void testSortProductsByRatingDesc() throws Exception {
+		// given
+		ProductCreateUpdateRequestDto createRequest1 = new ProductCreateUpdateRequestDto(
+			"name1",
+			"description1",
+			"address1",
+			1000,
+			0.5,
+			415L,
+			310L,
+			438L,
+			Set.of(351L)
+		);
+		ProductCreateUpdateRequestDto createRequest2 = new ProductCreateUpdateRequestDto(
+			"name2",
+			"description2",
+			"address2",
+			2000,
+			2.0,
+			431L,
+			310L,
+			442L,
+			Set.of(351L)
+		);
+		ProductCreateUpdateRequestDto createRequest3 = new ProductCreateUpdateRequestDto(
+			"name3",
+			"description3",
+			"address3",
+			3000,
+			3.5,
+			416L,
+			324L,
+			438L,
+			Set.of(350L, 351L)
+		);
+		ProductCreateUpdateRequestDto createRequest4 = new ProductCreateUpdateRequestDto(
+			"name4",
+			"description4",
+			"address4",
+			4000,
+			5.0,
+			423L,
+			315L,
+			439L,
+			Set.of(350L)
+		);
+		productService.createProduct(createRequest1);
+		productService.createProduct(createRequest2);
+		productService.createProduct(createRequest3);
+		productService.createProduct(createRequest4);
+
+		// when & then
+		mockMvc.perform(get("/v1/products")
+				.param("filter_id", "351", "350")
+				.param("sort_by", "rating")
+				.param("sort_direction", "DESC")
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.isSuccess", is(true)))
+			.andExpect(jsonPath("$.code", is("C000")))
+			.andExpect(jsonPath("$.data.content", hasSize(4)))
+			.andExpect(jsonPath("$.data.content[0].name", is(createRequest4.name())))
+			.andExpect(jsonPath("$.data.content[1].name", is(createRequest3.name())))
+			.andExpect(jsonPath("$.data.content[2].name", is(createRequest2.name())))
+			.andExpect(jsonPath("$.data.content[3].name", is(createRequest1.name())))
+			.andExpect(jsonPath("$.data.pageNumber", is(0)))
+			.andExpect(jsonPath("$.data.pageSize", is(ProductConstants.DEFAULT_PAGE_SIZE)))
+			.andExpect(jsonPath("$.data.totalElements", is(4)))
+			.andExpect(jsonPath("$.data.totalPages", is(1)))
+			.andExpect(jsonPath("$.data.last", is(true)))
+			.andExpect(jsonPath("$.timestamp", notNullValue()));
+	}
+
+	@Test
+	@DisplayName("좋아요 수로 오름차순 정렬된 상품 목록 조회 API 테스트")
+	public void testSortProductsByLikeCountAsc() throws Exception {
+		// when & then
+		mockMvc.perform(get("/v1/products")
+				.param("sort_by", "likeCount")
+				.param("sort_direction", "ASC")
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.isSuccess", is(true)))
+			.andExpect(jsonPath("$.code", is("C000")))
+			.andExpect(jsonPath("$.data.content", hasSize(3)))
+			.andExpect(jsonPath("$.data.content[0].name", is("왕족발 보쌈 과자")))
+			.andExpect(jsonPath("$.data.content[1].name", is("곤약젤리")))
+			.andExpect(jsonPath("$.data.content[2].name", is("여름 원피스")))
+			.andExpect(jsonPath("$.data.pageNumber", is(0)))
+			.andExpect(jsonPath("$.data.pageSize", is(ProductConstants.DEFAULT_PAGE_SIZE)))
+			.andExpect(jsonPath("$.data.totalElements", is(3)))
+			.andExpect(jsonPath("$.data.totalPages", is(1)))
+			.andExpect(jsonPath("$.data.last", is(true)))
+			.andExpect(jsonPath("$.timestamp", notNullValue()));
+	}
+
+	@Test
+	@DisplayName("좋아요 수로 내림차순 정렬된 상품 목록 조회 API 테스트")
+	public void testSortProductsByLikeCountDesc() throws Exception {
+		// when & then
+		mockMvc.perform(get("/v1/products")
+				.param("sort_by", "likeCount")
+				.param("sort_direction", "DESC")
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.isSuccess", is(true)))
+			.andExpect(jsonPath("$.code", is("C000")))
+			.andExpect(jsonPath("$.data.content", hasSize(3)))
+			.andExpect(jsonPath("$.data.content[0].name", is("여름 원피스")))
+			.andExpect(jsonPath("$.data.content[1].name", is("곤약젤리")))
+			.andExpect(jsonPath("$.data.content[2].name", is("왕족발 보쌈 과자")))
+			.andExpect(jsonPath("$.data.pageNumber", is(0)))
+			.andExpect(jsonPath("$.data.pageSize", is(ProductConstants.DEFAULT_PAGE_SIZE)))
+			.andExpect(jsonPath("$.data.totalElements", is(3)))
+			.andExpect(jsonPath("$.data.totalPages", is(1)))
+			.andExpect(jsonPath("$.data.last", is(true)))
+			.andExpect(jsonPath("$.timestamp", notNullValue()));
+	}
+
+	@Test
 	@DisplayName("상품 수정 API 테스트")
 	public void testUpdateProduct() throws Exception {
 		// given


### PR DESCRIPTION
## 📌 연관된 이슈
- **[KL-94/상품 정렬 기능](https://ohhamma.atlassian.net/browse/KL-94)**

## 📝 작업 내용
- 상품 정렬 기능 추가
  - 기준 : 좋아요수, 평점, 생성일자
  - 방향 : 오름차순, 내림차순
- 관련 테스트코드 수정 및 추가

## 🌳 작업 브랜치명
- `KL-94/상품-정렬-기능`

## 📸 스크린샷 (선택)

## 💬 리뷰 요구사항 (선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced sorting functionality for product retrieval, allowing users to sort by attributes such as creation date and rating.
	- Added new fields for sorting options in product queries, enhancing user control over displayed results.
	- Included a new metric, `like_count`, for products, providing additional insight into user engagement.

- **Bug Fixes**
	- Implemented error handling for invalid sorting options, ensuring users receive appropriate feedback for incorrect queries.

- **Tests**
	- Expanded test coverage to include various sorting scenarios, validating the integrity of the product retrieval process with new sorting capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->