### PR TITLE
feat(KL-157): add Location header

### DIFF
--- a/src/main/java/taco/klkl/domain/product/controller/ProductController.java
+++ b/src/main/java/taco/klkl/domain/product/controller/ProductController.java
@@ -1,10 +1,10 @@
 package taco.klkl.domain.product.controller;
 
+import java.net.URI;
 import java.util.Set;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -14,8 +14,8 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -86,11 +86,12 @@ public class ProductController {
 
 	@PostMapping
 	@Operation(summary = "상품 등록", description = "상품을 등록합니다.")
-	@ResponseStatus(HttpStatus.CREATED)
-	public ProductDetailResponse createProduct(
+	public ResponseEntity<ProductDetailResponse> createProduct(
 		@Valid @RequestBody ProductCreateUpdateRequest createRequest
 	) {
-		return productService.createProduct(createRequest);
+		ProductDetailResponse createdProduct = productService.createProduct(createRequest);
+		URI location = createResourceLocation(createdProduct.id());
+		return ResponseEntity.created(location).body(createdProduct);
 	}
 
 	@PutMapping("/{productId}")
@@ -111,4 +112,11 @@ public class ProductController {
 		return ResponseEntity.noContent().build();
 	}
 
+	private URI createResourceLocation(final Long resourceId) {
+		return ServletUriComponentsBuilder
+			.fromCurrentRequest()
+			.path("/{productId}")
+			.buildAndExpand(resourceId)
+			.toUri();
+	}
 }

--- a/src/main/java/taco/klkl/domain/product/service/ProductServiceImpl.java
+++ b/src/main/java/taco/klkl/domain/product/service/ProductServiceImpl.java
@@ -93,7 +93,7 @@ public class ProductServiceImpl implements ProductService {
 	public ProductDetailResponse findProductById(final Long id) throws ProductNotFoundException {
 		final Product product = productRepository.findById(id)
 			.orElseThrow(ProductNotFoundException::new);
-		return taco.klkl.domain.product.dto.response.ProductDetailResponse.from(product);
+		return ProductDetailResponse.from(product);
 	}
 
 	@Override
@@ -105,7 +105,7 @@ public class ProductServiceImpl implements ProductService {
 			Set<Tag> tags = createTagsByTagIds(createRequest.tagIds());
 			product.addTags(tags);
 		}
-		return taco.klkl.domain.product.dto.response.ProductDetailResponse.from(product);
+		return ProductDetailResponse.from(product);
 	}
 
 	@Override

--- a/src/test/java/taco/klkl/domain/product/controller/ProductControllerTest.java
+++ b/src/test/java/taco/klkl/domain/product/controller/ProductControllerTest.java
@@ -302,6 +302,7 @@ public class ProductControllerTest {
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(productCreateUpdateRequest)))
 			.andExpect(status().isCreated())
+			.andExpect(header().string("Location", containsString("/v1/products/")))
 			.andExpect(jsonPath("$.isSuccess", is(true)))
 			.andExpect(jsonPath("$.data.id", is(productDetailResponse.id().intValue())))
 			.andExpect(jsonPath("$.data.name", is(productDetailResponse.name())))

--- a/src/test/java/taco/klkl/domain/product/integration/ProductIntegrationTest.java
+++ b/src/test/java/taco/klkl/domain/product/integration/ProductIntegrationTest.java
@@ -98,6 +98,7 @@ public class ProductIntegrationTest {
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(new ObjectMapper().writeValueAsString(createRequest)))
 			.andExpect(status().isCreated())
+			.andExpect(header().string("Location", containsString("/v1/products/")))
 			.andExpect(jsonPath("$.isSuccess", is(true)))
 			.andExpect(jsonPath("$.data.id", notNullValue()))
 			.andExpect(jsonPath("$.data.name", is(createRequest.name())))


### PR DESCRIPTION
## 📌 연관된 이슈
- **[KL-157/상품 등록 시 Location 헤더 추가](https://ohhamma.atlassian.net/browse/KL-157)**

## 📝 작업 내용
- 상품 등록 시 Location 헤더 추가

## 🌳 작업 브랜치명
- `KL-157/상품-등록-시-location-헤더-추가`

## 📸 스크린샷 (선택)

## 💬 리뷰 요구사항 (선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced product creation API to return a more flexible response, including a "Location" header with the URI of the newly created product.
- **Bug Fixes**
	- Improved test coverage to validate that the response upon product creation includes the correct "Location" header.
- **Chores**
	- Simplified code for improved readability by using concise references for class names in the service implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->